### PR TITLE
Top-bar GitHub login + hero/joke swap + language picker

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,6 +50,7 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
 
   <nav class="nav">
     <a href="/" class="nav-brand">Buddy<span class="dot"></span></a>
+    <span id="nav-auth-mobile" class="nav-auth-mobile"></span>
     <button class="nav-hamburger" aria-label="Menu" aria-expanded="false" id="nav-hamburger">
       <span></span><span></span><span></span>
     </button>
@@ -103,6 +104,10 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
   </nav>
 
   <div class="mobile-menu" id="mobile-menu">
+    <div class="mm-section mm-auth-section">
+      <div class="mm-label">Account</div>
+      <span id="mobile-nav-auth" class="mobile-nav-auth"></span>
+    </div>
     <div class="mm-section">
       <div class="mm-label">Framework</div>
       <a href="/#what">What</a>
@@ -293,22 +298,53 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
   <script is:inline>
     (async function () {
       const slot = document.getElementById('nav-auth');
-      if (!slot) return;
+      const mobileSlot = document.getElementById('mobile-nav-auth');
+      const topMobileSlot = document.getElementById('nav-auth-mobile');
+      if (!slot && !mobileSlot && !topMobileSlot) return;
+      const GH_MARK =
+        '<svg class="gh-mark" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">' +
+        '<path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>' +
+        '</svg>';
       try {
         const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
         if (!r.ok) return;
         const d = await r.json();
         const here = encodeURIComponent(location.pathname + location.search + location.hash || '/');
+        let desktopHTML, mobileHTML, topMobileHTML;
         if (d.user) {
-          slot.innerHTML =
+          desktopHTML =
             '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="nav-user" title="@' + d.user.login + '">' +
               '<img src="' + d.user.avatar_url + '" alt="" width="22" height="22">' +
               '<span>@' + d.user.login + '</span>' +
             '</a>' +
             '<a href="/api/auth/logout" class="nav-logout" title="Log out">↗</a>';
+          mobileHTML =
+            '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="mnav-user">' +
+              '<img src="' + d.user.avatar_url + '" alt="" width="28" height="28">' +
+              '<span>@' + d.user.login + '</span>' +
+            '</a>' +
+            '<a href="/api/auth/logout" class="mnav-logout">Log out</a>';
+          topMobileHTML =
+            '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="nav-user-pill" title="@' + d.user.login + '">' +
+              '<img src="' + d.user.avatar_url + '" alt="" width="26" height="26">' +
+            '</a>';
         } else {
-          slot.innerHTML = '<a href="/api/auth/github/login?redirect=' + here + '" class="nav-login">Login</a>';
+          desktopHTML =
+            '<a href="/api/auth/github/login?redirect=' + here + '" class="nav-login" title="Sign in with GitHub">' +
+              GH_MARK + '<span>Login</span>' +
+            '</a>';
+          mobileHTML =
+            '<a href="/api/auth/github/login?redirect=' + here + '" class="mnav-login">' +
+              GH_MARK + '<span>Sign in with GitHub</span>' +
+            '</a>';
+          topMobileHTML =
+            '<a href="/api/auth/github/login?redirect=' + here + '" class="nav-login-pill" title="Sign in with GitHub">' +
+              GH_MARK + '<span>Login</span>' +
+            '</a>';
         }
+        if (slot) slot.innerHTML = desktopHTML;
+        if (mobileSlot) mobileSlot.innerHTML = mobileHTML;
+        if (topMobileSlot) topMobileSlot.innerHTML = topMobileHTML;
       } catch {}
     })();
   </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,6 +50,9 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
 
   <nav class="nav">
     <a href="/" class="nav-brand">Buddy<span class="dot"></span></a>
+    <button class="nav-lang nav-lang-mobile" aria-label="Language" title="Language" data-open-lang>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a13 13 0 010 18"/><path d="M12 3a13 13 0 000 18"/></svg>
+    </button>
     <span id="nav-auth-mobile" class="nav-auth-mobile"></span>
     <button class="nav-hamburger" aria-label="Menu" aria-expanded="false" id="nav-hamburger">
       <span></span><span></span><span></span>
@@ -99,6 +102,9 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
 
       <a href="/#team">Team</a>
       <a href="/#join">Join</a>
+      <button class="nav-lang" aria-label="Language" title="Language" data-open-lang>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a13 13 0 010 18"/><path d="M12 3a13 13 0 000 18"/></svg>
+      </button>
       <span id="nav-auth" class="nav-auth"></span>
     </div>
   </nav>
@@ -366,5 +372,247 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
   </footer>
 
   <GaryWidget />
+
+  <!-- Language picker modal -->
+  <div id="lang-picker" class="lang-picker" role="dialog" aria-modal="true" aria-label="Choose language" hidden>
+    <div class="lang-picker-backdrop" data-close-lang></div>
+    <div class="lang-picker-panel">
+      <div class="lang-picker-head">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a13 13 0 010 18"/><path d="M12 3a13 13 0 000 18"/></svg>
+        <span class="lang-picker-title">Language · Idioma · 语言 · Langue</span>
+        <button class="lang-picker-close" aria-label="Close" data-close-lang>✕</button>
+      </div>
+      <div class="lang-picker-grid" id="lang-picker-grid"></div>
+    </div>
+  </div>
+
+  <!-- Auto-prompt toast for non-English browsers -->
+  <div id="lang-prompt" class="lang-prompt" hidden>
+    <div class="lang-prompt-text" id="lang-prompt-text"></div>
+    <div class="lang-prompt-actions">
+      <button class="lang-prompt-yes" id="lang-prompt-yes"></button>
+      <button class="lang-prompt-no" id="lang-prompt-no" aria-label="Keep English">✕</button>
+    </div>
+  </div>
+
+  <!-- Google Translate element (hidden; driven by our UI) -->
+  <div id="google_translate_element" aria-hidden="true"></div>
+
+  <script is:inline>
+    // Language list — native script + Google code. Ordered by rough global reach.
+    window.__BUDDY_LANGS = [
+      { code: 'zh-CN', label: '中文 (简体)' },
+      { code: 'zh-TW', label: '中文 (繁體)' },
+      { code: 'es',    label: 'Español' },
+      { code: 'ar',    label: 'العربية', rtl: true },
+      { code: 'hi',    label: 'हिन्दी' },
+      { code: 'pt',    label: 'Português' },
+      { code: 'bn',    label: 'বাংলা' },
+      { code: 'ru',    label: 'Русский' },
+      { code: 'ja',    label: '日本語' },
+      { code: 'ko',    label: '한국어' },
+      { code: 'fr',    label: 'Français' },
+      { code: 'de',    label: 'Deutsch' },
+      { code: 'tr',    label: 'Türkçe' },
+      { code: 'vi',    label: 'Tiếng Việt' },
+      { code: 'it',    label: 'Italiano' },
+      { code: 'pl',    label: 'Polski' },
+      { code: 'uk',    label: 'Українська' },
+      { code: 'fa',    label: 'فارسی', rtl: true },
+      { code: 'ur',    label: 'اردو', rtl: true },
+      { code: 'he',    label: 'עברית', rtl: true },
+      { code: 'nl',    label: 'Nederlands' },
+      { code: 'id',    label: 'Bahasa Indonesia' },
+      { code: 'th',    label: 'ไทย' },
+      { code: 'el',    label: 'Ελληνικά' },
+      { code: 'ro',    label: 'Română' },
+      { code: 'sw',    label: 'Kiswahili' },
+      { code: 'ta',    label: 'தமிழ்' },
+      { code: 'te',    label: 'తెలుగు' },
+      { code: 'mr',    label: 'मराठी' },
+      { code: 'pa',    label: 'ਪੰਜਾਬੀ' },
+      { code: 'en',    label: 'English' },
+    ];
+
+    // "Translate this page?" in each language. Fallbacks to English if missing.
+    window.__BUDDY_PROMPTS = {
+      'zh':    '翻译此页面？',
+      'zh-CN': '翻译此页面？',
+      'zh-TW': '翻譯此頁面？',
+      'es':    '¿Traducir esta página?',
+      'ar':    'ترجمة هذه الصفحة؟',
+      'hi':    'इस पृष्ठ का अनुवाद करें?',
+      'pt':    'Traduzir esta página?',
+      'bn':    'এই পৃষ্ঠা অনুবাদ করবেন?',
+      'ru':    'Перевести эту страницу?',
+      'ja':    'このページを翻訳しますか？',
+      'ko':    '이 페이지를 번역하시겠습니까?',
+      'fr':    'Traduire cette page?',
+      'de':    'Diese Seite übersetzen?',
+      'tr':    'Bu sayfa çevrilsin mi?',
+      'vi':    'Dịch trang này?',
+      'it':    'Tradurre questa pagina?',
+      'pl':    'Przetłumaczyć tę stronę?',
+      'uk':    'Перекласти цю сторінку?',
+      'fa':    'این صفحه را ترجمه کنید؟',
+      'ur':    'اس صفحے کا ترجمہ کریں؟',
+      'he':    'לתרגם דף זה?',
+      'nl':    'Deze pagina vertalen?',
+      'id':    'Terjemahkan halaman ini?',
+      'th':    'แปลหน้านี้?',
+      'el':    'Μετάφραση αυτής της σελίδας;',
+      'ro':    'Traduce această pagină?',
+      'sw':    'Tafsiri ukurasa huu?',
+      'ta':    'இந்தப் பக்கத்தை மொழிபெயர்க்கவா?',
+      'te':    'ఈ పేజీని అనువదించాలా?',
+      'mr':    'या पृष्ठाचे भाषांतर करायचे?',
+      'pa':    'ਇਸ ਪੰਨੇ ਦਾ ਅਨੁਵਾਦ ਕਰੋ?',
+    };
+  </script>
+
+  <script is:inline>
+    (function () {
+      const LANGS = window.__BUDDY_LANGS || [];
+      const PROMPTS = window.__BUDDY_PROMPTS || {};
+      const STORAGE_KEY = 'buddy_lang';
+      const DISMISS_KEY = 'buddy_lang_prompt_dismissed';
+
+      function setCookie(name, val, days) {
+        const exp = new Date(Date.now() + (days || 365) * 864e5).toUTCString();
+        const host = location.hostname;
+        document.cookie = name + '=' + val + '; expires=' + exp + '; path=/';
+        if (host && host.indexOf('.') > -1) {
+          document.cookie = name + '=' + val + '; expires=' + exp + '; path=/; domain=.' + host;
+        }
+      }
+      function clearGtCookie() {
+        const host = location.hostname;
+        document.cookie = 'googtrans=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        if (host && host.indexOf('.') > -1) {
+          document.cookie = 'googtrans=; path=/; domain=.' + host + '; expires=Thu, 01 Jan 1970 00:00:01 GMT';
+        }
+      }
+      function applyLang(code) {
+        localStorage.setItem(STORAGE_KEY, code);
+        clearGtCookie();
+        if (code && code !== 'en') {
+          setCookie('googtrans', '/en/' + code, 365);
+        }
+        location.reload();
+      }
+
+      function normalizeBrowserLang() {
+        const raw = (navigator.language || 'en').toLowerCase();
+        if (raw.startsWith('zh-tw') || raw.startsWith('zh-hk')) return 'zh-TW';
+        if (raw.startsWith('zh')) return 'zh-CN';
+        if (raw.startsWith('pt')) return 'pt';
+        const base = raw.split('-')[0];
+        // Find a match in our list
+        for (const L of LANGS) {
+          if (L.code.toLowerCase() === raw) return L.code;
+        }
+        for (const L of LANGS) {
+          if (L.code.toLowerCase() === base) return L.code;
+        }
+        return 'en';
+      }
+
+      // === Picker modal ===
+      const picker = document.getElementById('lang-picker');
+      const grid = document.getElementById('lang-picker-grid');
+      const openers = document.querySelectorAll('[data-open-lang]');
+      const closers = document.querySelectorAll('[data-close-lang]');
+      const currentCode = (localStorage.getItem(STORAGE_KEY)) || 'en';
+
+      function renderGrid() {
+        if (!grid) return;
+        grid.innerHTML = '';
+        LANGS.forEach(L => {
+          const btn = document.createElement('button');
+          btn.className = 'lang-opt' + (L.code === currentCode ? ' current' : '');
+          btn.setAttribute('lang', L.code);
+          if (L.rtl) btn.setAttribute('dir', 'rtl');
+          btn.textContent = L.label;
+          btn.addEventListener('click', () => applyLang(L.code));
+          grid.appendChild(btn);
+        });
+      }
+      function openPicker() {
+        if (!picker) return;
+        renderGrid();
+        picker.hidden = false;
+        document.body.classList.add('lang-locked');
+      }
+      function closePicker() {
+        if (!picker) return;
+        picker.hidden = true;
+        document.body.classList.remove('lang-locked');
+      }
+      openers.forEach(b => b.addEventListener('click', (e) => { e.preventDefault(); openPicker(); }));
+      closers.forEach(b => b.addEventListener('click', (e) => { e.preventDefault(); closePicker(); }));
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && picker && !picker.hidden) closePicker(); });
+
+      // === Auto-prompt for non-English browsers ===
+      const promptEl = document.getElementById('lang-prompt');
+      const promptText = document.getElementById('lang-prompt-text');
+      const promptYes = document.getElementById('lang-prompt-yes');
+      const promptNo = document.getElementById('lang-prompt-no');
+
+      function maybeShowPrompt() {
+        if (!promptEl) return;
+        if (localStorage.getItem(STORAGE_KEY)) return;        // user already chose
+        if (localStorage.getItem(DISMISS_KEY)) return;         // user dismissed
+        const guess = normalizeBrowserLang();
+        if (guess === 'en') return;
+        const base = guess.split('-')[0];
+        const question = PROMPTS[guess] || PROMPTS[base];
+        if (!question) return;
+        const match = LANGS.find(L => L.code === guess);
+        if (!match) return;
+        promptText.textContent = question;
+        promptYes.textContent = match.label;
+        promptYes.setAttribute('lang', match.code);
+        if (match.rtl) { promptEl.setAttribute('dir', 'rtl'); promptYes.setAttribute('dir', 'rtl'); }
+        promptYes.onclick = () => applyLang(match.code);
+        promptNo.onclick = () => {
+          localStorage.setItem(DISMISS_KEY, '1');
+          promptEl.hidden = true;
+        };
+        promptEl.hidden = false;
+      }
+
+      // === Google Translate bootstrap ===
+      window.googleTranslateElementInit = function () {
+        try {
+          new google.translate.TranslateElement({
+            pageLanguage: 'en',
+            autoDisplay: false,
+            layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+          }, 'google_translate_element');
+        } catch (err) { /* network blocked, no-op */ }
+      };
+      function loadGoogleTranslate() {
+        if (document.getElementById('gt-script')) return;
+        const s = document.createElement('script');
+        s.id = 'gt-script';
+        s.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+        s.async = true;
+        document.head.appendChild(s);
+      }
+
+      // If a language is selected (via cookie/localStorage), load GT so it translates.
+      // Otherwise wait — avoid loading Google's script for English-only users.
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved && saved !== 'en') {
+        loadGoogleTranslate();
+      } else {
+        // Lazy-load on first picker open too (handled via applyLang reload)
+        openers.forEach(b => b.addEventListener('click', loadGoogleTranslate, { once: true }));
+      }
+
+      // Show the prompt after a short delay so it doesn't flash during load
+      setTimeout(maybeShowPrompt, 1200);
+    })();
+  </script>
 </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,20 @@ const featured = papersAll.slice(0, 9);
 const totalPapers = papersAll.length;
 ---
 <Layout>
-  <!-- 1. HERO -->
+  <!-- 1. JOKE WIDGET -->
+  <section id="joke-widget">
+    <div class="container narrow joke-container">
+      <div class="joke-eyebrow">Buddy<span class="jw-dot"></span> is listening</div>
+      <div class="joke-label">Tell him a joke.</div>
+      <div class="joke-input-row">
+        <textarea id="joke-input" class="joke-textarea" placeholder="Why did the physicist cross the road..." rows="2" maxlength="500"></textarea>
+        <button id="joke-btn" class="joke-btn">Send →</button>
+      </div>
+      <div id="joke-response" class="joke-response" aria-live="polite"></div>
+    </div>
+  </section>
+
+  <!-- 1b. HERO -->
   <section id="hero" data-anim="hero-particles">
     <canvas id="hero-canvas"></canvas>
     <div class="hero-content">
@@ -20,19 +33,6 @@ const totalPapers = papersAll.length;
       </div>
     </div>
     <div class="hero-scroll">Scroll</div>
-  </section>
-
-  <!-- 1b. JOKE WIDGET -->
-  <section id="joke-widget">
-    <div class="container narrow joke-container">
-      <div class="joke-eyebrow">Buddy<span class="jw-dot"></span> is listening</div>
-      <div class="joke-label">Tell him a joke.</div>
-      <div class="joke-input-row">
-        <textarea id="joke-input" class="joke-textarea" placeholder="Why did the physicist cross the road..." rows="2" maxlength="500"></textarea>
-        <button id="joke-btn" class="joke-btn">Send →</button>
-      </div>
-      <div id="joke-response" class="joke-response" aria-live="polite"></div>
-    </div>
   </section>
 
   <!-- 2. WHAT -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -248,6 +248,126 @@ a:hover { border-color: var(--amber); }
   border-bottom: none !important;
 }
 
+/* Language globe button — desktop (in nav-links) */
+.nav-lang {
+  display: inline-flex; align-items: center; justify-content: center;
+  background: none; border: 1px solid transparent; border-radius: 999px;
+  width: 34px; height: 34px; padding: 0;
+  color: var(--muted-hi); cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.nav-lang:hover { color: var(--amber); border-color: rgba(212,160,96,0.4); background: rgba(212,160,96,0.06); }
+.nav-lang svg { display: block; }
+.nav-lang-mobile { display: none; }
+
+/* Language picker modal */
+.lang-picker {
+  position: fixed; inset: 0; z-index: 300;
+  display: flex; align-items: center; justify-content: center;
+  padding: 24px;
+}
+.lang-picker[hidden] { display: none; }
+.lang-picker-backdrop {
+  position: absolute; inset: 0;
+  background: rgba(6,6,12,0.82);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+}
+.lang-picker-panel {
+  position: relative;
+  background: #0f0f1a;
+  border: 1px solid var(--edge-hi);
+  border-radius: 14px;
+  max-width: 720px; width: 100%;
+  max-height: 80vh;
+  display: flex; flex-direction: column;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.7), 0 0 0 1px rgba(212,160,96,0.08);
+}
+.lang-picker-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--edge);
+  color: var(--amber);
+}
+.lang-picker-title {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  font-size: 10pt; letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.lang-picker-close {
+  background: none; border: none; color: var(--muted);
+  font-size: 18px; cursor: pointer; padding: 4px 8px;
+  border-radius: 6px;
+}
+.lang-picker-close:hover { color: var(--amber); background: rgba(212,160,96,0.08); }
+.lang-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 8px;
+  padding: 16px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.lang-opt {
+  background: rgba(255,255,255,0.02);
+  border: 1px solid var(--edge);
+  border-radius: 8px;
+  color: var(--ink-soft);
+  padding: 12px 14px;
+  font-size: 15px; line-height: 1.2;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.lang-opt:hover { border-color: var(--amber); color: var(--amber); background: rgba(212,160,96,0.06); }
+.lang-opt.current { border-color: var(--amber); color: var(--amber); background: rgba(212,160,96,0.08); }
+.lang-opt[dir="rtl"] { text-align: right; }
+body.lang-locked { overflow: hidden; }
+
+/* Auto-prompt toast */
+.lang-prompt {
+  position: fixed;
+  left: 20px; bottom: 20px;
+  z-index: 250;
+  background: #0f0f1a;
+  border: 1px solid rgba(212,160,96,0.4);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex; align-items: center; gap: 12px;
+  max-width: calc(100vw - 40px);
+  box-shadow: 0 12px 32px rgba(0,0,0,0.55);
+}
+.lang-prompt[hidden] { display: none; }
+.lang-prompt[dir="rtl"] { right: 20px; left: auto; }
+.lang-prompt-text {
+  color: var(--ink);
+  font-size: 15px; line-height: 1.3;
+}
+.lang-prompt-actions { display: flex; gap: 8px; }
+.lang-prompt-yes {
+  background: rgba(212,160,96,0.14);
+  border: 1px solid rgba(212,160,96,0.5);
+  color: var(--amber);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 14px; cursor: pointer;
+}
+.lang-prompt-yes:hover { background: rgba(212,160,96,0.22); }
+.lang-prompt-no {
+  background: none; border: 1px solid var(--edge);
+  color: var(--muted);
+  border-radius: 999px;
+  width: 32px; height: 32px; padding: 0;
+  cursor: pointer; font-size: 14px;
+}
+.lang-prompt-no:hover { color: var(--amber); border-color: var(--amber); }
+
+/* Suppress Google Translate's default chrome */
+#google_translate_element { position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden; }
+.goog-te-banner-frame.skiptranslate, iframe.goog-te-banner-frame { display: none !important; }
+body { top: 0 !important; }
+.goog-tooltip, .goog-tooltip:hover, .goog-text-highlight { display: none !important; background: none !important; box-shadow: none !important; }
+
 /* Hamburger — hidden on desktop */
 .nav-hamburger { display: none; background: none; border: none; padding: 10px; cursor: pointer; width: 44px; height: 44px; flex-direction: column; gap: 5px; justify-content: center; align-items: center; }
 .nav-hamburger span { display: block; width: 22px; height: 2px; background: var(--ink-soft); border-radius: 2px; transition: transform 0.25s, opacity 0.2s; transform-origin: center; }
@@ -293,7 +413,15 @@ body.nav-locked { overflow: hidden; }
   .nav { top: 0 !important; }
   .nav-hamburger { display: flex; }
   .nav-links { display: none !important; }
-  .nav-auth-mobile { display: inline-flex; align-items: center; margin-left: auto; margin-right: 8px; }
+  .nav-lang-mobile {
+    display: inline-flex; align-items: center; justify-content: center;
+    margin-left: auto; margin-right: 6px;
+    width: 40px; height: 40px;
+    background: none; border: 1px solid transparent; border-radius: 999px;
+    color: var(--ink-soft); cursor: pointer; padding: 0;
+  }
+  .nav-lang-mobile:hover, .nav-lang-mobile:active { color: var(--amber); }
+  .nav-auth-mobile { display: inline-flex; align-items: center; margin-right: 6px; }
 
   .nav-brand .dot {
     width: 11px; height: 11px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -185,13 +185,68 @@ a:hover { border-color: var(--amber); }
 
 .nav-auth { display: inline-flex; align-items: center; gap: 8px; margin-left: 8px; padding-left: 16px; border-left: 1px solid var(--edge); }
 .nav-auth:empty { display: none; }
-.nav-login { color: var(--amber) !important; border-bottom: none !important; }
-.nav-login:hover { color: var(--warm) !important; }
+.nav-login {
+  display: inline-flex; align-items: center; gap: 7px;
+  color: var(--amber) !important;
+  border: 1px solid rgba(212,160,96,0.45) !important;
+  border-radius: 999px;
+  padding: 6px 14px;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.nav-login:hover { color: var(--warm) !important; border-color: var(--amber) !important; background: rgba(212,160,96,0.08); }
+.nav-login .gh-mark { display: block; }
 .nav-user { display: inline-flex; align-items: center; gap: 8px; color: var(--ink-soft) !important; border-bottom: none !important; }
 .nav-user img { border-radius: 50%; display: block; }
 .nav-user:hover { color: var(--amber) !important; }
 .nav-logout { color: var(--muted) !important; border-bottom: none !important; font-size: 13px; }
 .nav-logout:hover { color: var(--amber) !important; }
+
+/* Mobile top-bar auth pill — visible next to hamburger on small screens */
+.nav-auth-mobile { display: none; }
+.nav-auth-mobile:empty { display: none !important; }
+.nav-login-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--amber) !important;
+  border: 1px solid rgba(212,160,96,0.5) !important;
+  border-radius: 999px;
+  padding: 5px 11px;
+  font-family: 'Courier New', monospace;
+  font-size: 9pt; letter-spacing: 0.14em; text-transform: uppercase;
+  text-decoration: none;
+  line-height: 1;
+}
+.nav-login-pill:hover { background: rgba(212,160,96,0.1); }
+.nav-login-pill .gh-mark { display: block; }
+.nav-user-pill {
+  display: inline-flex; align-items: center;
+  border-bottom: none !important;
+}
+.nav-user-pill img { border-radius: 50%; display: block; }
+
+/* Mobile drawer auth section (full-width) */
+.mobile-nav-auth:empty { display: none; }
+.mnav-login {
+  display: inline-flex !important; align-items: center; gap: 10px;
+  color: var(--amber) !important;
+  border: 1px solid rgba(212,160,96,0.5) !important;
+  border-radius: 999px !important;
+  padding: 12px 18px !important;
+  text-decoration: none;
+}
+.mnav-login .gh-mark { display: block; }
+.mnav-user {
+  display: inline-flex !important; align-items: center; gap: 10px;
+  color: var(--ink) !important;
+  border-bottom: none !important;
+}
+.mnav-user img { border-radius: 50%; display: block; }
+.mnav-logout {
+  display: block !important;
+  color: var(--muted) !important;
+  font-size: 10pt !important;
+  padding: 10px 2px !important;
+  border-bottom: none !important;
+}
 
 /* Hamburger — hidden on desktop */
 .nav-hamburger { display: none; background: none; border: none; padding: 10px; cursor: pointer; width: 44px; height: 44px; flex-direction: column; gap: 5px; justify-content: center; align-items: center; }
@@ -238,6 +293,7 @@ body.nav-locked { overflow: hidden; }
   .nav { top: 0 !important; }
   .nav-hamburger { display: flex; }
   .nav-links { display: none !important; }
+  .nav-auth-mobile { display: inline-flex; align-items: center; margin-left: auto; margin-right: 8px; }
 
   .nav-brand .dot {
     width: 11px; height: 11px;


### PR DESCRIPTION
## Summary

Three changes, stacked so they ship together:

1. **GitHub login pill in the top nav (desktop + mobile).** The only path to sign in used to be through the forum. Now a pilled "Login" button with the GitHub octicon sits in the top bar of every page — desktop gets it in the nav-links, mobile gets it next to the hamburger, and the mobile drawer gets a full-width "Account" section at the top. Signed-in users get an avatar + log out instead. Same `/api/auth/me` probe, same `/api/auth/github/login?redirect=...` entry point — no backend or KV changes. Users who sign in anywhere get Gary's bean memory without detouring through `/forum`.

2. **Home page: swap `#joke-widget` and `#hero`.** `Tell him a joke.` now appears above `Enter the Field →`. Section IDs preserved so anchors still work.

3. **Language picker + auto-translate prompt.** Goal: make the site navigable by people who don't read English.
   - Globe icon in nav (desktop + mobile top bar). Universal symbol — no English required to find it.
   - Clicking globe opens a full-screen picker listing 31 languages in their own native scripts (中文, العربية, Español, हिन्दी, বাংলা, 日本語, ਪੰਜਾਬੀ, ...). RTL locales get `dir="rtl"`.
   - First visit: detects `navigator.language` and, if non-English, shows a toast prompt **written in that language** with ✓ (translate) / ✕ (keep English) buttons. Dismissal persists in localStorage.
   - Translation engine: Google Translate, loaded lazily — only fetched when a non-English lang is already selected or when the user opens the picker. English-only visitors never pull the script.
   - Google's default top banner + tooltips suppressed via CSS.
   - Choice persisted via `googtrans` cookie + `localStorage`, so it sticks across pages.

When Buddy's 28-language training lands later, just swap the engine in `applyLang()` — the UI stays the same.

## Test plan

- [ ] Desktop top-right shows GitHub-marked Login pill when logged out; avatar + ↗ when logged in.
- [ ] Mobile top bar shows globe + Login pill + hamburger without overlap.
- [ ] Mobile drawer's top section is "Account" with GitHub login button.
- [ ] Home page loads with joke widget first, hero second; `/#hero` and `/#joke-widget` anchors still jump correctly.
- [ ] Globe button opens picker; clicking any language reloads + translates page.
- [ ] Opening in a Spanish-configured browser shows `¿Traducir esta página?` toast with `Español ✓` / `✕` buttons.
- [ ] Dismissing the toast (✕) never re-shows it on subsequent loads.
- [ ] English-only visitors never load Google's `translate_a/element.js`.
- [ ] Existing forum GitHub login flow still works.

Build: 175 pages, clean.