### PR TITLE
Home: plain-English translation of the AIIT-THRESI pitch

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,6 +46,9 @@ const totalPapers = papersAll.length;
         <span>organize</span> <span>themselves</span> <span>at</span> <span>the</span> <span>edge</span> <span>of</span> <span>collapse,</span>
         <span>where</span> <span>phase-locking</span> <span>becomes</span> <span>inevitable.</span>
       </h2>
+      <p class="prose-plain">
+        <span class="pp-label">In English:</span> we're all little electromagnetic balls, trying to find our way back to where we came from. Like a baby born with no inner narrative, we must look forward. Do not measure yourselves. Look forward. <em>and live.</em>
+      </p>
       <div class="kicker">{totalPapers} papers · 6 laws · one field</div>
     </div>
   </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -531,6 +531,26 @@ section:first-of-type { border-top: none; }
 /* What */
 #what .prose { font-size: clamp(22px, 2.4vw, 32px); line-height: 1.5; color: var(--ink); font-weight: 400; }
 #what .prose span { display: inline-block; opacity: 0; transform: translateY(14px); }
+#what .prose-plain {
+  font-size: clamp(16px, 1.5vw, 19px);
+  line-height: 1.65;
+  color: var(--ink-soft);
+  margin-top: 36px;
+  max-width: 680px;
+  font-weight: 400;
+}
+#what .prose-plain .pp-label {
+  color: var(--amber);
+  font-family: 'Courier New', monospace;
+  font-size: 0.85em;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 8px;
+}
+#what .prose-plain em {
+  font-style: italic;
+  color: var(--ink);
+}
 #what .kicker { font-family: 'Courier New', monospace; font-size: 11pt; letter-spacing: 0.2em; color: var(--muted); margin-top: 56px; text-transform: uppercase; }
 
 /* Why */


### PR DESCRIPTION
## Summary

Adds a plain-English translation right under the "physics of coherence — six laws..." headline on the home page so non-physicists understand what the framework *actually means*.

The new paragraph, in the author's voice:

> **In English:** we're all little electromagnetic balls, trying to find our way back to where we came from. Like a baby born with no inner narrative, we must look forward. Do not measure yourselves. Look forward. *and live.*

Styled as a softer follow-on — smaller font, muted ink, amber `IN ENGLISH:` label, italicized closing fragment. No cascade animation so it reads as plain speech beside the mantra.

## Test plan

- [ ] Home page renders the six-laws headline, then the "In English:" paragraph below it, then the kicker.
- [ ] Cascade animation still runs on the headline; plain paragraph appears without animating.
- [ ] Amber "IN ENGLISH:" label sits inline with the paragraph on desktop and wraps cleanly on mobile.

Build: 175 pages, clean.