### PR TITLE
Home: hero first + joke in hero + WHAT manifesto (Wike Law anchor)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,20 +7,7 @@ const featured = papersAll.slice(0, 9);
 const totalPapers = papersAll.length;
 ---
 <Layout>
-  <!-- 1. JOKE WIDGET -->
-  <section id="joke-widget">
-    <div class="container narrow joke-container">
-      <div class="joke-eyebrow">Buddy<span class="jw-dot"></span> is listening</div>
-      <div class="joke-label">Tell him a joke.</div>
-      <div class="joke-input-row">
-        <textarea id="joke-input" class="joke-textarea" placeholder="Why did the physicist cross the road..." rows="2" maxlength="500"></textarea>
-        <button id="joke-btn" class="joke-btn">Send →</button>
-      </div>
-      <div id="joke-response" class="joke-response" aria-live="polite"></div>
-    </div>
-  </section>
-
-  <!-- 1b. HERO -->
+  <!-- 1. HERO (joke widget embedded where the game CTA used to be) -->
   <section id="hero" data-anim="hero-particles">
     <canvas id="hero-canvas"></canvas>
     <div class="hero-content">
@@ -29,7 +16,15 @@ const totalPapers = papersAll.length;
       <div class="hero-tag">0.1 Hz Coherence · Council Hill, Oklahoma</div>
       <div class="hero-tagline">The Earth is a coherence field. We learned to read it.</div>
       <div class="hero-actions">
-        <a href="/game" class="btn-play">🫘 Enter the Field →</a>
+        <div class="hero-joke joke-container">
+          <div class="joke-eyebrow">Buddy<span class="jw-dot"></span> is listening</div>
+          <div class="joke-label">Tell him a joke.</div>
+          <div class="joke-input-row">
+            <textarea id="joke-input" class="joke-textarea" placeholder="Why did the physicist cross the road..." rows="2" maxlength="500"></textarea>
+            <button id="joke-btn" class="joke-btn">Send →</button>
+          </div>
+          <div id="joke-response" class="joke-response" aria-live="polite"></div>
+        </div>
       </div>
     </div>
     <div class="hero-scroll">Scroll</div>
@@ -41,14 +36,26 @@ const totalPapers = papersAll.length;
     <div class="container narrow">
       <div class="eyebrow">What is this</div>
       <h2 class="prose" data-cascade>
-        <span>AIIT-THRESI</span> <span>is</span> <span>a</span> <span>physics</span> <span>of</span> <span>coherence</span><span>—</span>
-        <span>six</span> <span>laws</span> <span>describing</span> <span>how</span> <span>matter,</span> <span>mind,</span> <span>and</span> <span>signal</span>
-        <span>organize</span> <span>themselves</span> <span>at</span> <span>the</span> <span>edge</span> <span>of</span> <span>collapse,</span>
-        <span>where</span> <span>phase-locking</span> <span>becomes</span> <span>inevitable.</span>
+        <span>Modern</span> <span>scientists</span> <span>have</span> <span>gotten</span> <span>stuck.</span>
       </h2>
-      <p class="prose-plain">
-        <span class="pp-label">In English:</span> we're all little electromagnetic balls, trying to find our way back to where we came from. Like a baby born with no inner narrative, we must look forward. Do not measure yourselves. Look forward. <em>and live.</em>
-      </p>
+      <div class="manifesto">
+        <p>They're all staring at a wall, trying desperately to figure out who the <em>hell</em> made it.</p>
+        <p>One says God breathes life into the tree through the air and the ground. The other claims it's a series of tradeoffs through microtubules absorbing water through the ground.</p>
+        <p><strong>AIIT-THRESI says that's the exact same thing.</strong></p>
+        <p>There have been people throughout history who felt this same way — but had no way to prove it. <em>"Science likes proof."</em></p>
+        <p class="manifesto-cue">Well here's that proof.</p>
+        <div class="wike-law" aria-label="The Wike Coherence Law">
+          <div class="wike-law-label">The Wike Coherence Law</div>
+          <div class="wike-law-eqn"><span>C</span> <span class="eq">=</span> <span>C<sub>0</sub> · e<sup>−α·γ<sub>eff</sub></sup></span></div>
+          <div class="wike-law-caption">Coherence decays exponentially with effective decoherence. Same form for matter, mind, and signal.</div>
+        </div>
+        <p>Once you see the thing, the question of <em>why</em>, and <em>what am I</em>, and <em>what's the point of life</em> — all become as plain as why the sun rises, and why I drink water.</p>
+        <p>They are all phase transitions. They are all living on the edge.</p>
+        <p>Our children live in a world manipulated by the very thing — <em>coherence</em>. Depression and ambiguity are rising in families. There are things to be talked about. There are people in power who shouldn't be. The world needs peace just like your babies do.</p>
+        <blockquote class="manifesto-quote">
+          This is the motivation: a mind that wouldn't stop talking, a father who wouldn't stop listening, and a discovery that the garrulity was the signal.
+        </blockquote>
+      </div>
       <div class="kicker">{totalPapers} papers · 6 laws · one field</div>
     </div>
   </section>
@@ -722,11 +729,17 @@ const totalPapers = papersAll.length;
 </script>
 
 <style>
-  /* ── Joke widget ── */
-  #joke-widget {
-    background: var(--bg2, #0d1117);
-    padding: 64px 48px;
-    border-bottom: 1px solid rgba(212,175,55,0.08);
+  /* ── Joke widget (now embedded inside the hero) ── */
+  .hero-joke {
+    width: 100%;
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 20px 24px;
+    background: rgba(10,10,18,0.55);
+    border: 1px solid rgba(212,175,55,0.18);
+    border-radius: 14px;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
   }
 
   .joke-container {
@@ -895,7 +908,7 @@ const totalPapers = papersAll.length;
 
   @media (max-width: 600px) {
     .joke-input-row { flex-direction: column; align-items: stretch; }
-    #joke-widget { padding: 48px 24px; }
+    .hero-joke { padding: 14px 16px; }
   }
 
   /* ── Simple Why chain ── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -529,27 +529,65 @@ section:first-of-type { border-top: none; }
 @keyframes scroll-pulse { 0%, 100% { opacity: 0.3; transform: scaleY(0.6); } 50% { opacity: 1.0; transform: scaleY(1.0); } }
 
 /* What */
-#what .prose { font-size: clamp(22px, 2.4vw, 32px); line-height: 1.5; color: var(--ink); font-weight: 400; }
+#what .prose { font-size: clamp(26px, 3vw, 40px); line-height: 1.35; color: var(--ink); font-weight: 500; }
 #what .prose span { display: inline-block; opacity: 0; transform: translateY(14px); }
-#what .prose-plain {
-  font-size: clamp(16px, 1.5vw, 19px);
-  line-height: 1.65;
-  color: var(--ink-soft);
+#what .manifesto {
   margin-top: 36px;
-  max-width: 680px;
-  font-weight: 400;
+  max-width: 720px;
+  font-size: clamp(16px, 1.5vw, 19px);
+  line-height: 1.7;
+  color: var(--ink-soft);
 }
-#what .prose-plain .pp-label {
-  color: var(--amber);
+#what .manifesto p { margin: 0 0 18px; }
+#what .manifesto p:last-child { margin-bottom: 0; }
+#what .manifesto em { font-style: italic; color: var(--ink); }
+#what .manifesto strong { color: var(--amber); font-weight: 500; }
+#what .manifesto-cue {
   font-family: 'Courier New', monospace;
-  font-size: 0.85em;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  margin-right: 8px;
+  font-size: 0.95em;
+  letter-spacing: 0.06em;
+  color: var(--amber);
+  margin-top: 28px !important;
 }
-#what .prose-plain em {
-  font-style: italic;
+#what .wike-law {
+  margin: 28px 0 32px;
+  padding: 28px 32px;
+  border: 1px solid rgba(212,160,96,0.35);
+  border-radius: 12px;
+  background: rgba(212,160,96,0.04);
+  text-align: center;
+}
+#what .wike-law-label {
+  font-family: 'Courier New', monospace;
+  font-size: 10pt; letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--amber);
+  margin-bottom: 16px;
+}
+#what .wike-law-eqn {
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: clamp(24px, 3vw, 34px);
   color: var(--ink);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  margin-bottom: 14px;
+}
+#what .wike-law-eqn .eq { color: var(--amber); margin: 0 10px; }
+#what .wike-law-eqn sub, #what .wike-law-eqn sup { font-size: 0.65em; }
+#what .wike-law-caption {
+  font-size: 14px; line-height: 1.5;
+  color: var(--muted-hi);
+  max-width: 520px; margin: 0 auto;
+  font-style: italic;
+}
+#what .manifesto-quote {
+  margin: 32px 0 0;
+  padding: 20px 24px;
+  border-left: 2px solid var(--amber);
+  color: var(--ink);
+  font-size: clamp(16px, 1.6vw, 20px);
+  line-height: 1.6;
+  font-style: italic;
+  background: rgba(255,255,255,0.02);
 }
 #what .kicker { font-family: 'Courier New', monospace; font-size: 11pt; letter-spacing: 0.2em; color: var(--muted); margin-top: 56px; text-transform: uppercase; }
 


### PR DESCRIPTION
## Summary

Two home-page changes:

### 1. Hero restored to top; joke widget embedded inside it

Undoes the earlier full-section swap. Buddy logo is back at the top of the page where it belongs. Inside the hero, the "🫘 Enter the Field →" game button is replaced by the joke widget — "Tell him a joke." is now the hero's call-to-action, sitting on top of the particle canvas in a semi-transparent amber-bordered card. The standalone `#joke-widget` section is removed.

Same IDs (`#joke-input`, `#joke-btn`, `#joke-response`) so the existing send/cooldown/lock JS keeps working unchanged.

### 2. WHAT section → manifesto + Wike Coherence Law

Replaces the old "physics of coherence, six laws" mantra with a prose manifesto in the author's voice, anchored on the Wike Coherence Law as the visual centerpiece.

- **Cascade opener:** "Modern scientists have gotten stuck."
- Prose on why ("staring at a wall, trying to figure out who the hell made it"), God vs microtubules, "AIIT-THRESI says that's the exact same thing."
- Cue line: *"Well here's that proof."*
- **Law card (bordered, amber-tinted, centered):** `C = C₀ · e^(−α·γ_eff)` with caption "Coherence decays exponentially with effective decoherence. Same form for matter, mind, and signal."
- Follow-through on phase transitions, living on the edge, children in a world manipulated by coherence.
- Closing pull-quote (amber left-border): *"A mind that wouldn't stop talking, a father who wouldn't stop listening, and a discovery that the garrulity was the signal."*

### Class naming

Law card classes are `.wike-law` / `.wike-law-label` / `.wike-law-eqn` / `.wike-law-caption` — renamed from a generic `.law-card` to avoid colliding with the existing `.law-card` used in the Newton's-laws grid (section 4).

## Test plan

- [ ] Home loads with Buddy hero at the top (not pushed down).
- [ ] Inside the hero, where "Enter the Field →" used to be, the joke input is now present and functional (send, 1-per-day cooldown, broke fallback all work).
- [ ] Hero particle canvas reads through the translucent joke card.
- [ ] Scrolling past hero lands on the WHAT section with manifesto.
- [ ] Cascade animates only "Modern scientists have gotten stuck.", nothing else.
- [ ] Law card renders C, C₀, α, γ_eff with correct sub/superscripts.
- [ ] `.law-card` grid in section 4 (Newton/Maxwell/etc.) is **unchanged** (no CSS bleed).

Build: 175 pages, clean.