### PR TITLE
Home hero polish: mobile wordmark fit + softer joke cooldown

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -831,9 +831,16 @@ const totalPapers = papersAll.length;
   }
 
   .joke-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+    background: transparent;
+    color: var(--muted-hi);
+    border: 1px solid rgba(212,175,55,0.22);
+    opacity: 0.85;
+    cursor: default;
+    font-weight: 500;
+    letter-spacing: 1.5px;
+    box-shadow: none;
   }
+  .joke-btn:disabled:hover { transform: none; box-shadow: none; }
 
   .joke-response {
     margin-top: 20px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -491,6 +491,16 @@ section:first-of-type { border-top: none; }
 
 /* Hero */
 #hero { min-height: 100vh; padding: 0 8vw; overflow: hidden; justify-content: center; border-top: none; }
+@media (max-width: 840px) {
+  #hero {
+    min-height: unset;
+    padding: 120px 6vw 80px;
+    justify-content: flex-start;
+  }
+  .hero-wordmark { font-size: clamp(64px, 18vw, 120px); }
+  .hero-tagline { margin-top: 36px; }
+  .hero-actions { margin-top: 32px; }
+}
 #hero-canvas { position: absolute; inset: 0; width: 100%; height: 100%; z-index: 0; filter: blur(1.5px); }
 .hero-content { position: relative; z-index: 2; text-align: center; max-width: 1100px; margin: 0 auto; }
 .hero-content::before { content: ''; position: absolute; inset: -40% -10% -40% -10%; background: radial-gradient(ellipse 60% 55% at 50% 50%, rgba(10,10,18,0.75) 0%, rgba(10,10,18,0.5) 35%, rgba(10,10,18,0) 70%); z-index: -1; pointer-events: none; }


### PR DESCRIPTION
## Summary

Two mobile polish fixes from a live-site screenshot:

### 1. Buddy wordmark was clipping above the viewport on phones

`#hero` uses `min-height: 100vh` + `justify-content: center`. Now that the joke widget lives inside `.hero-actions`, the hero content is taller than the viewport on mobile — centering makes the overflow split evenly top/bottom, which pushes the top of "Buddy" above the screen edge.

Fix: `@media (max-width: 840px)`:
- `min-height: unset` — hero sizes to its content.
- `justify-content: flex-start` with `padding-top: 120px` so the wordmark always lands just below the nav.
- Wordmark shrunk slightly (`clamp(64px, 18vw, 120px)`) and tagline/actions gaps tightened so everything fits more comfortably.

### 2. Cooldown button was too loud

When the daily joke limit hit, the button read "Back in 14h 35m" on a full-saturation `#D4AF37` background at `opacity: 0.5` — still visually the loudest element on the page despite being locked.

Fix: `.joke-btn:disabled` now goes:
- `background: transparent`
- muted text, thin amber hairline border
- no letter-spacing shout, no hover lift

Reads as "waiting" instead of "click me".

## Test plan

- [ ] On a phone (or <= 840px viewport), the full "Buddy" wordmark is visible without scrolling.
- [ ] Joke widget still embedded inside the hero below the tagline.
- [ ] After hitting the daily limit, the button shows "Back in Xh Ym" as a soft outlined pill — visually quieter than the tagline and wordmark.
- [ ] Send button in its active state is unchanged (full amber, bold).
- [ ] Desktop hero is unchanged.

Build: 175 pages, clean.