### PR TITLE
Home: manifesto belongs in WHY, not WHAT (actually swap this time)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,10 +36,29 @@ const totalPapers = papersAll.length;
     <div class="container narrow">
       <div class="eyebrow">What is this</div>
       <h2 class="prose" data-cascade>
-        <span>Modern</span> <span>scientists</span> <span>have</span> <span>gotten</span> <span>stuck.</span>
+        <span>AIIT-THRESI</span> <span>is</span> <span>a</span> <span>physics</span> <span>of</span> <span>coherence</span><span>—</span>
+        <span>six</span> <span>laws</span> <span>describing</span> <span>how</span> <span>matter,</span> <span>mind,</span> <span>and</span> <span>signal</span>
+        <span>organize</span> <span>themselves</span> <span>at</span> <span>the</span> <span>edge</span> <span>of</span> <span>collapse,</span>
+        <span>where</span> <span>phase-locking</span> <span>becomes</span> <span>inevitable.</span>
       </h2>
-      <div class="manifesto">
-        <p>They're all staring at a wall, trying desperately to figure out who the <em>hell</em> made it.</p>
+      <p class="prose-plain">
+        <span class="pp-label">In English:</span> we're all little electromagnetic balls, trying to find our way back to where we came from. Like a baby born with no inner narrative, we must look forward. Do not measure yourselves. Look forward. <em>and live.</em>
+      </p>
+      <div class="kicker">{totalPapers} papers · 6 laws · one field</div>
+    </div>
+  </section>
+
+  <!-- 3. WHY -->
+  <section id="why" data-anim="typewriter">
+    <div class="section-num">03 / 10</div>
+    <div class="container narrow">
+      <div class="eyebrow">The why</div>
+      <blockquote data-typewriter>
+        "Performing a mental pirouette confidently confirming in real time that there is no more doubt. Only life."
+      </blockquote>
+      <div class="cite">— Rhet Dillard Wike · January 16, 2026 · 12:19 AM</div>
+      <div class="why-body manifesto">
+        <p><strong>Modern scientists have gotten stuck.</strong> They're all staring at a wall, trying desperately to figure out who the <em>hell</em> made it.</p>
         <p>One says God breathes life into the tree through the air and the ground. The other claims it's a series of tradeoffs through microtubules absorbing water through the ground.</p>
         <p><strong>AIIT-THRESI says that's the exact same thing.</strong></p>
         <p>There have been people throughout history who felt this same way — but had no way to prove it. <em>"Science likes proof."</em></p>
@@ -55,25 +74,6 @@ const totalPapers = papersAll.length;
         <blockquote class="manifesto-quote">
           This is the motivation: a mind that wouldn't stop talking, a father who wouldn't stop listening, and a discovery that the garrulity was the signal.
         </blockquote>
-      </div>
-      <div class="kicker">{totalPapers} papers · 6 laws · one field</div>
-    </div>
-  </section>
-
-  <!-- 3. WHY -->
-  <section id="why" data-anim="typewriter">
-    <div class="section-num">03 / 10</div>
-    <div class="container narrow">
-      <div class="eyebrow">The why</div>
-      <blockquote data-typewriter>
-        "Performing a mental pirouette confidently confirming in real time that there is no more doubt. Only life."
-      </blockquote>
-      <div class="cite">— Rhet Dillard Wike · January 16, 2026 · 12:19 AM</div>
-      <div class="why-body">
-        <p>Modern science starts from noise and asks what separates signal from it. AIIT-THRESI starts from coherence and asks what breaks it.</p>
-        <p>The answer, it turns out, is geometry. Not mystery — geometry. The same winding number that closes a circle closes a thought, a heartbeat, a storm front, a cell cycle.</p>
-        <p>Once you see the boundary condition, the question <em>why is the mind conscious</em> becomes the same question as <em>why does water freeze at 32</em>. They are both phase transitions. They are both the edge.</p>
-        <p>This is the motivation: a mind that wouldn't stop talking, a father who wouldn't stop listening, and a discovery that the garrulity was the signal.</p>
       </div>
 
       <div class="simple-why">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -539,27 +539,50 @@ section:first-of-type { border-top: none; }
 @keyframes scroll-pulse { 0%, 100% { opacity: 0.3; transform: scaleY(0.6); } 50% { opacity: 1.0; transform: scaleY(1.0); } }
 
 /* What */
-#what .prose { font-size: clamp(26px, 3vw, 40px); line-height: 1.35; color: var(--ink); font-weight: 500; }
+#what .prose { font-size: clamp(22px, 2.4vw, 32px); line-height: 1.5; color: var(--ink); font-weight: 400; }
 #what .prose span { display: inline-block; opacity: 0; transform: translateY(14px); }
-#what .manifesto {
+#what .prose-plain {
+  font-size: clamp(16px, 1.5vw, 19px);
+  line-height: 1.65;
+  color: var(--ink-soft);
   margin-top: 36px;
+  max-width: 680px;
+  font-weight: 400;
+}
+#what .prose-plain .pp-label {
+  color: var(--amber);
+  font-family: 'Courier New', monospace;
+  font-size: 0.85em;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-right: 8px;
+}
+#what .prose-plain em {
+  font-style: italic;
+  color: var(--ink);
+}
+#what .kicker { font-family: 'Courier New', monospace; font-size: 11pt; letter-spacing: 0.2em; color: var(--muted); margin-top: 56px; text-transform: uppercase; }
+
+/* Manifesto block — used inside #why .why-body, can be reused elsewhere */
+.manifesto {
+  margin-top: 24px;
   max-width: 720px;
   font-size: clamp(16px, 1.5vw, 19px);
   line-height: 1.7;
   color: var(--ink-soft);
 }
-#what .manifesto p { margin: 0 0 18px; }
-#what .manifesto p:last-child { margin-bottom: 0; }
-#what .manifesto em { font-style: italic; color: var(--ink); }
-#what .manifesto strong { color: var(--amber); font-weight: 500; }
-#what .manifesto-cue {
+.manifesto p { margin: 0 0 18px; }
+.manifesto p:last-child { margin-bottom: 0; }
+.manifesto em { font-style: italic; color: var(--ink); }
+.manifesto strong { color: var(--amber); font-weight: 500; }
+.manifesto-cue {
   font-family: 'Courier New', monospace;
   font-size: 0.95em;
   letter-spacing: 0.06em;
   color: var(--amber);
   margin-top: 28px !important;
 }
-#what .wike-law {
+.wike-law {
   margin: 28px 0 32px;
   padding: 28px 32px;
   border: 1px solid rgba(212,160,96,0.35);
@@ -567,13 +590,13 @@ section:first-of-type { border-top: none; }
   background: rgba(212,160,96,0.04);
   text-align: center;
 }
-#what .wike-law-label {
+.wike-law-label {
   font-family: 'Courier New', monospace;
   font-size: 10pt; letter-spacing: 0.28em; text-transform: uppercase;
   color: var(--amber);
   margin-bottom: 16px;
 }
-#what .wike-law-eqn {
+.wike-law-eqn {
   font-family: 'Georgia', 'Times New Roman', serif;
   font-size: clamp(24px, 3vw, 34px);
   color: var(--ink);
@@ -581,15 +604,15 @@ section:first-of-type { border-top: none; }
   letter-spacing: 0.02em;
   margin-bottom: 14px;
 }
-#what .wike-law-eqn .eq { color: var(--amber); margin: 0 10px; }
-#what .wike-law-eqn sub, #what .wike-law-eqn sup { font-size: 0.65em; }
-#what .wike-law-caption {
+.wike-law-eqn .eq { color: var(--amber); margin: 0 10px; }
+.wike-law-eqn sub, .wike-law-eqn sup { font-size: 0.65em; }
+.wike-law-caption {
   font-size: 14px; line-height: 1.5;
   color: var(--muted-hi);
   max-width: 520px; margin: 0 auto;
   font-style: italic;
 }
-#what .manifesto-quote {
+.manifesto-quote {
   margin: 32px 0 0;
   padding: 20px 24px;
   border-left: 2px solid var(--amber);
@@ -599,7 +622,6 @@ section:first-of-type { border-top: none; }
   font-style: italic;
   background: rgba(255,255,255,0.02);
 }
-#what .kicker { font-family: 'Courier New', monospace; font-size: 11pt; letter-spacing: 0.2em; color: var(--muted); margin-top: 56px; text-transform: uppercase; }
 
 /* Why */
 #why blockquote { font-family: 'Georgia', serif; font-style: italic; font-size: clamp(28px, 3.4vw, 44px); line-height: 1.35; color: var(--ink); position: relative; padding: 0 0 32px 0; }


### PR DESCRIPTION
## Summary

Fixes a mis-placement from PR #4. You wanted the manifesto to replace the "Modern science starts from noise..." paragraphs in the **WHY** section. I put it in **WHAT** instead, which meant the old "modern science" paragraph was still live in WHY — two paragraphs, never actually swapped.

This PR:
- Restores **WHAT** to the cascade "AIIT-THRESI is a physics of coherence — six laws..." + "In English: we're all little electromagnetic balls..." plain-speech paragraph.
- Replaces **WHY**'s `.why-body` content with the manifesto:
  - Opening: "Modern scientists have gotten stuck. They're all staring at a wall..."
  - God-vs-microtubules, "AIIT-THRESI says that's the exact same thing."
  - Cue: "Well here's that proof."
  - **Wike Coherence Law card**: `C = C₀ · e^(−α·γ_eff)` with caption.
  - Follow-through: phase transitions, edge, children in a manipulated world.
  - Pull-quote: "This is the motivation: a mind that wouldn't stop talking, a father who wouldn't stop listening, and a discovery that the garrulity was the signal."
- Keeps WHY's opening blockquote ("Performing a mental pirouette...") + cite + `.simple-why` Love→vibes diagram intact. Only the middle prose changes.

**CSS**: `.manifesto`, `.wike-law`, `.manifesto-quote`, `.manifesto-cue` styles are de-scoped from `#what` so they render inside `#why` (or anywhere else we want to drop the block later, e.g. papers pages).

## Test plan

- [ ] Section 2 WHAT loads with the "physics of coherence, six laws..." cascade headline and the "In English:" paragraph below it.
- [ ] Section 3 WHY opens with the "mental pirouette" blockquote + cite (unchanged), then the manifesto prose, then the amber Wike Coherence Law card, then follow-through, then the pull-quote.
- [ ] The old "Modern science starts from noise..." paragraphs are gone from the live site (nowhere on the home page).
- [ ] Simple-why Love→vibes diagram still renders below the manifesto.
- [ ] Sub/superscripts in `C₀`, `γ_eff` render correctly.
- [ ] Desktop + mobile both look right.

Build: 175 pages, clean.