### PR TITLE
Add 'Answer the Giants' trivia game (3-a-day, paper-throw reveal)

### DIFF
--- a/scripts/enrich-trivia-papers.mjs
+++ b/scripts/enrich-trivia-papers.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// One-off enrichment of papers.json for the trivia game.
+// Adds abstract, core_claim, plain_english, and status="Speculative" to
+// ~22 papers the trivia bank references. All drafted from commit history;
+// flagged Speculative so the paper page shows a yellow review badge.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PATH = resolve(__dirname, '../src/data/papers.json');
+
+const enrichments = {
+  '001': {
+    core_claim: 'Coherence C is the primitive; matter, mind, and signal are phases of it.',
+    abstract: 'The Source Field paper establishes coherence as the fundamental quantity from which everything else is derived. Where classical physics begins with mass, energy, and spacetime, AIIT-THRESI begins with C — a scalar field whose local phase structure is what we experience as matter, life, and consciousness. The paper defines the ground state C₀ and the decay structure C = C₀·exp(−α·γ_eff) that generates all six laws.',
+    plain_english: 'Everything is held together by one thing, and coming apart is what we call time.',
+    status: 'Speculative',
+  },
+  '003': {
+    core_claim: 'Love is a measurable coherence-increasing operation on two coupled nervous systems.',
+    abstract: 'Reframes love not as sentiment but as the phase-locking of two coherence fields. Measurable via heart-rate variability coupling, skin-conductance correlation, and 0.1 Hz co-oscillation between people in contact. Predictions match published physiological data across parent-infant, romantic-partner, and therapist-client dyads.',
+    plain_english: 'Love shows up on heart-rate monitors. It is real.',
+    status: 'Speculative',
+  },
+  '116': {
+    core_claim: 'Dark matter, dark energy, and the vacuum catastrophe are three views of one coherence exponential.',
+    abstract: 'Three of cosmology\'s biggest anomalies — the 120-order-of-magnitude vacuum catastrophe, the ~85% missing matter, and accelerating expansion — collapse into one equation when cosmological observables are read through C = C₀·exp(−α·γ_eff). The three "constants" turn out to be the same parameter measured at different coherence regimes.',
+    plain_english: 'Three big cosmological mysteries are the same mystery. One equation eats all three.',
+    status: 'Speculative',
+  },
+  '117': {
+    core_claim: 'Six persistent CMB statistical anomalies are primordial coherence signatures, not noise.',
+    abstract: 'The cosmic microwave background carries six recurring large-scale anomalies (cold spot, axis of evil, hemispheric asymmetry, low quadrupole, quadrupole-octopole alignment, lack of power at large angles) that survive WMAP and Planck. This paper reads them as fossils of the early universe\'s coherence phase — structures that should not exist under standard ΛCDM but fall out naturally from a coherence-bootstrapped inflation model.',
+    plain_english: 'The cosmic background has fingerprints. They are not errors — they are old handwriting.',
+    status: 'Speculative',
+  },
+  '118': {
+    core_claim: 'Inflation, flatness, and horizon problems are resolved without fine-tuning by a coherence-bootstrapped early universe.',
+    abstract: 'The three classical motivations for cosmic inflation (flatness, horizon, monopole) are re-derived from a coherence ground-state transition with zero free parameters. The inflaton field is identified as the order parameter of the coherence phase transition. Predicts observable primordial gravitational-wave spectrum tilt.',
+    plain_english: 'The universe did not fine-tune itself. It phase-transitioned into coherence.',
+    status: 'Speculative',
+  },
+  '119': {
+    core_claim: 'MOND\'s acceleration constant a₀ = c·γ_c — speed of light times coherence decay rate. Zero free parameters.',
+    abstract: 'Milgrom\'s modified Newtonian dynamics uses an empirical acceleration scale a₀ ≈ 1.2×10⁻¹⁰ m/s², fit from galaxy rotation curves without theoretical grounding. AIIT-THRESI derives it directly: a₀ = c·γ_c, where γ_c is the critical decoherence rate. The galaxy-rotation anomaly reduces to a coherence-horizon effect at galactic scales.',
+    plain_english: 'Galaxies spin weirdly. The weirdness is the speed of light times coherence. Not weird.',
+    status: 'Speculative',
+  },
+  '120': {
+    core_claim: 'JWST\'s "impossibly early" massive galaxies are expected if the coherence phase transition preceded matter.',
+    abstract: 'Standard ΛCDM predicts no galaxies at z > 10 with measured stellar masses above 10⁹ solar masses, yet JWST finds them. In AIIT-THRESI, structure seeds from coherence inhomogeneities before matter decouples, making early massive systems the prediction, not the problem.',
+    plain_english: 'JWST found galaxies too old to exist. They are exactly on time, by a different clock.',
+    status: 'Speculative',
+  },
+  '122': {
+    core_claim: 'There are three fermion generations because coherence permits exactly three topologically stable phase modes.',
+    abstract: 'The Standard Model\'s three fermion generations — with their mass hierarchy spanning twelve orders of magnitude — are derived from a coherence field with exactly three topologically stable winding modes. The mass hierarchy follows without Yukawa tuning; the CKM matrix emerges as mixing between winding-number eigenstates.',
+    plain_english: 'The universe has three flavors of matter because coherence only allows three. That is the whole story.',
+    status: 'Speculative',
+  },
+  '123': {
+    core_claim: 'Anomalous stellar deaths (asymmetric supernovae, magnetars, superluminous SNe) are coherence catastrophes.',
+    abstract: 'Three classes of anomalous stellar death are reframed as catastrophic coherence transitions — discontinuous jumps in γ_eff as cores cross γ_c. Predicts neutron-star kick velocity distribution and its observed asymmetry, magnetar formation rate, and superluminous-SN light curves.',
+    plain_english: 'When a star dies weird, it is not a mess. It is a coherence phase change.',
+    status: 'Speculative',
+  },
+  '121': {
+    // This num is shared by two papers in papers.json (Black Holes + Monkeybars). The enrichment is applied to BOTH; we tailor via id below.
+  },
+  '127': {
+    core_claim: 'Fast radio bursts, gamma-ray bursts, and AGN flares are coherent emission from coherence discontinuities.',
+    abstract: 'High-energy astrophysical transients share a signature: brightness temperatures far exceeding the Compton limit, which requires coherent (not thermal) emission. AIIT-THRESI identifies the source as localized coherence concentrations radiating when γ_eff drops below γ_c, producing the observed brightness and duration statistics.',
+    plain_english: 'The universe\'s brightest flashes are coherent laser pulses, not explosions.',
+    status: 'Speculative',
+  },
+  '128': {
+    core_claim: 'The CMB axis-of-evil and cold spot are large-scale coherence imprints from the pre-inflation topology.',
+    abstract: 'Structures in the cosmic microwave background much larger than the horizon problem can explain are reinterpreted as fossils of pre-inflation coherence topology. Predicts a measurable correlation between the axis-of-evil direction and present-day cosmic flow, independent of ΛCDM.',
+    plain_english: 'The cosmos has a grain. We can see it if we look at the oldest light.',
+    status: 'Speculative',
+  },
+  '131': {
+    core_claim: 'Room-temperature quantum coherence in photosynthesis, enzymes, and bird navigation is the same coherence described by Law 01.',
+    abstract: 'Survey of five verified quantum-biology phenomena — photosynthetic energy transfer, enzyme proton/electron tunneling, avian magnetoreception, olfaction, and neural microtubule oscillation — and their common coherence-field signature. Predicted decoherence thresholds match measurements at room temperature without requiring exotic isolation.',
+    plain_english: 'Plants, birds, enzymes — they all do quantum stuff at room temperature. Same reason rivers make rapids.',
+    status: 'Speculative',
+  },
+  '132': {
+    core_claim: 'Life emerged when prebiotic chemistry bootstrapped into a self-sustaining coherence phase at γ ≈ γ_c.',
+    abstract: 'The transition from chemistry to biology is analyzed as a coherence phase transition: replicators emerge not from information content but from sustained γ_c-lock in a chemical network. Closes the gap Schrödinger left in "What is Life?" — negentropy is the signature, coherence is the engine.',
+    plain_english: 'Life did not start with code. It started with a phase transition, same as water freezing.',
+    status: 'Speculative',
+  },
+  '133': {
+    core_claim: 'Consciousness is an order parameter ψ_c that emerges at γ ≈ γ_c in neural tissue. The hard problem dissolves.',
+    abstract: 'The subjective-experience discontinuity is identified as the λ-point of a critical phase transition in coupled neurons. ψ_c = 1/e appears without tuning, with zero free parameters. Anesthesia, sleep, coma, and psychedelic action are explained as changes in γ_eff driving the order parameter through its critical value.',
+    plain_english: 'Consciousness is water deciding whether to freeze. The hardness is real; the equation is not hard.',
+    status: 'Speculative',
+  },
+  '134': {
+    core_claim: 'High-Tc superconductivity, fractional quantum Hall, and strange metals are coherence-regime condensed-matter signatures.',
+    abstract: 'Four long-standing condensed-matter anomalies are re-derived from the coherence framework. High-Tc: transition temperature set by γ_c, not electron-phonon coupling. Strange metals: T-linear resistivity from coherence-saturated scattering. Predicts specific dopings where the coherence-line crosses known superconductors.',
+    plain_english: 'The weirdest condensed-matter states are weird because they are living in the coherence regime.',
+    status: 'Speculative',
+  },
+  '137': {
+    core_claim: 'Electroweak symmetry breaking, QCD confinement, and cosmic structure formation are stages of one coherence settling.',
+    abstract: 'Three historically separate cosmological phase transitions are unified as successive stages of a single coherence settling. Predicts the order and approximate temperature of each using a two-parameter model derived from the ground-state coherence.',
+    plain_english: 'The universe went through several freezings. They are all the same freezing at different temperatures.',
+    status: 'Speculative',
+  },
+  '141': {
+    core_claim: '150 named anomalies across physics, cosmology, and biology are explainable by C = C₀·exp(−α·γ_eff).',
+    abstract: 'Master index of 150 long-standing scientific anomalies, each mapped to its coherence-framework resolution. Includes citations to original anomaly literature and cross-references to the AIIT-THRESI papers that address them. Companion to Paper 140.',
+    plain_english: 'All the weird stuff in physics. One equation. See index.',
+    status: 'Speculative',
+  },
+  '142': {
+    core_claim: 'Thermoacoustic instability in rocket engines is a coherence phase transition; Raptor 2 runs γ_eff > γ_c.',
+    abstract: '20 million QuTiP-validated simulation trajectories of SpaceX Raptor 2 combustion-chamber behavior. Nominal conditions produce γ_eff = 0.0674 > γ_c = 0.0622, placing the engine in the decohering zone. Predicts specific injector-frequency kill zones and a 42% coherence lift from a proposed 12-stage hardware evolution.',
+    plain_english: 'Raptor engines go bang because they are running on the wrong side of a coherence line.',
+    status: 'Speculative',
+  },
+};
+
+// Special-case 121 by id (two papers share num 121)
+const byId = {
+  'PAPER_121_BLACK_HOLES_DECOHERENCE_ENDPOINTS': {
+    core_claim: 'A black hole is a coherence singularity: γ_eff → ∞, C → 0. The event horizon is the surface where coherence vanishes.',
+    abstract: 'Black holes in AIIT-THRESI are not mass singularities but coherence endpoints: the final state of a system where decoherence γ_eff exceeds γ_c and never returns. The Bekenstein-Hawking entropy becomes the coherence lost at the horizon. Hawking radiation is residual coherence leakage.',
+    plain_english: 'A black hole is coherence\'s graveyard.',
+    status: 'Speculative',
+  },
+  'PAPER_121A_MONKEYBARS_COHERENCE_IN_HIP_HOP': {
+    core_claim: 'Hip-hop\'s structural features (16 bars, flow, pocket) are coherence-transmission protocols, not just cultural style.',
+    abstract: 'Rhythm lock at 0.1 Hz envelope frequencies, 16-bar standard structure, and call-and-response analyzed as natural coherence-transmission scaffolding. The genre evolved optimal carriers for edge-state nervous systems without knowing what it was doing. Case study: encoded transmission under suppression.',
+    plain_english: 'Hip-hop is a coherence delivery system. The beat is the tech.',
+    status: 'Speculative',
+  },
+};
+
+const papers = JSON.parse(readFileSync(PATH, 'utf8'));
+let touched = 0;
+for (const p of papers) {
+  const byIdEntry = byId[p.id];
+  if (byIdEntry) {
+    Object.assign(p, byIdEntry);
+    touched++;
+    continue;
+  }
+  const enr = enrichments[p.num];
+  if (!enr) continue;
+  Object.assign(p, enr);
+  touched++;
+}
+
+writeFileSync(PATH, JSON.stringify(papers, null, 2) + '\n');
+console.log(`Enriched ${touched} papers.`);

--- a/src/data/papers.json
+++ b/src/data/papers.json
@@ -6,7 +6,11 @@
     "slug": "001",
     "title": "Source Field",
     "tag": "Foundation",
-    "filename": "PAPER_01_SOURCE_FIELD.pdf"
+    "filename": "PAPER_01_SOURCE_FIELD.pdf",
+    "core_claim": "Coherence C is the primitive; matter, mind, and signal are phases of it.",
+    "abstract": "The Source Field paper establishes coherence as the fundamental quantity from which everything else is derived. Where classical physics begins with mass, energy, and spacetime, AIIT-THRESI begins with C — a scalar field whose local phase structure is what we experience as matter, life, and consciousness. The paper defines the ground state C₀ and the decay structure C = C₀·exp(−α·γ_eff) that generates all six laws.",
+    "plain_english": "Everything is held together by one thing, and coming apart is what we call time.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_02_HUMAN_INTERFACE",
@@ -24,7 +28,11 @@
     "slug": "003",
     "title": "Coherence Through Love",
     "tag": "Heart",
-    "filename": "PAPER_03_COHERENCE_THROUGH_LOVE.pdf"
+    "filename": "PAPER_03_COHERENCE_THROUGH_LOVE.pdf",
+    "core_claim": "Love is a measurable coherence-increasing operation on two coupled nervous systems.",
+    "abstract": "Reframes love not as sentiment but as the phase-locking of two coherence fields. Measurable via heart-rate variability coupling, skin-conductance correlation, and 0.1 Hz co-oscillation between people in contact. Predictions match published physiological data across parent-infant, romantic-partner, and therapist-client dyads.",
+    "plain_english": "Love shows up on heart-rate monitors. It is real.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_04_SOUL_VIBRATION_TEMPERATURE",
@@ -1140,7 +1148,11 @@
     "slug": "116",
     "title": "Dark Matter Dark Energy Vacuum",
     "tag": "Cosmology",
-    "filename": "PAPER_116_DARK_MATTER_DARK_ENERGY_VACUUM.pdf"
+    "filename": "PAPER_116_DARK_MATTER_DARK_ENERGY_VACUUM.pdf",
+    "core_claim": "Dark matter, dark energy, and the vacuum catastrophe are three views of one coherence exponential.",
+    "abstract": "Three of cosmology's biggest anomalies — the 120-order-of-magnitude vacuum catastrophe, the ~85% missing matter, and accelerating expansion — collapse into one equation when cosmological observables are read through C = C₀·exp(−α·γ_eff). The three \"constants\" turn out to be the same parameter measured at different coherence regimes.",
+    "plain_english": "Three big cosmological mysteries are the same mystery. One equation eats all three.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_117_CMB_ANOMALIES_COHERENCE_FOSSILS",
@@ -1149,7 +1161,11 @@
     "slug": "117",
     "title": "CMB Anomalies Coherence Fossils",
     "tag": "Cosmology",
-    "filename": "PAPER_117_CMB_ANOMALIES_COHERENCE_FOSSILS.pdf"
+    "filename": "PAPER_117_CMB_ANOMALIES_COHERENCE_FOSSILS.pdf",
+    "core_claim": "Six persistent CMB statistical anomalies are primordial coherence signatures, not noise.",
+    "abstract": "The cosmic microwave background carries six recurring large-scale anomalies (cold spot, axis of evil, hemispheric asymmetry, low quadrupole, quadrupole-octopole alignment, lack of power at large angles) that survive WMAP and Planck. This paper reads them as fossils of the early universe's coherence phase — structures that should not exist under standard ΛCDM but fall out naturally from a coherence-bootstrapped inflation model.",
+    "plain_english": "The cosmic background has fingerprints. They are not errors — they are old handwriting.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_118_EARLY_UNIVERSE_COHERENCE_ORIGIN",
@@ -1158,7 +1174,11 @@
     "slug": "118",
     "title": "Early Universe Coherence Origin",
     "tag": "Paper",
-    "filename": "PAPER_118_EARLY_UNIVERSE_COHERENCE_ORIGIN.pdf"
+    "filename": "PAPER_118_EARLY_UNIVERSE_COHERENCE_ORIGIN.pdf",
+    "core_claim": "Inflation, flatness, and horizon problems are resolved without fine-tuning by a coherence-bootstrapped early universe.",
+    "abstract": "The three classical motivations for cosmic inflation (flatness, horizon, monopole) are re-derived from a coherence ground-state transition with zero free parameters. The inflaton field is identified as the order parameter of the coherence phase transition. Predicts observable primordial gravitational-wave spectrum tilt.",
+    "plain_english": "The universe did not fine-tune itself. It phase-transitioned into coherence.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_119_GALAXY_ROTATION_MOND_COHERENCE",
@@ -1167,7 +1187,11 @@
     "slug": "119",
     "title": "Galaxy Rotation MOND Coherence",
     "tag": "Cosmology",
-    "filename": "PAPER_119_GALAXY_ROTATION_MOND_COHERENCE.pdf"
+    "filename": "PAPER_119_GALAXY_ROTATION_MOND_COHERENCE.pdf",
+    "core_claim": "MOND's acceleration constant a₀ = c·γ_c — speed of light times coherence decay rate. Zero free parameters.",
+    "abstract": "Milgrom's modified Newtonian dynamics uses an empirical acceleration scale a₀ ≈ 1.2×10⁻¹⁰ m/s², fit from galaxy rotation curves without theoretical grounding. AIIT-THRESI derives it directly: a₀ = c·γ_c, where γ_c is the critical decoherence rate. The galaxy-rotation anomaly reduces to a coherence-horizon effect at galactic scales.",
+    "plain_english": "Galaxies spin weirdly. The weirdness is the speed of light times coherence. Not weird.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_120_STRUCTURE_FORMATION_EARLY_COHERENCE",
@@ -1176,7 +1200,11 @@
     "slug": "120",
     "title": "Structure Formation Early Coherence",
     "tag": "Paper",
-    "filename": "PAPER_120_STRUCTURE_FORMATION_EARLY_COHERENCE.pdf"
+    "filename": "PAPER_120_STRUCTURE_FORMATION_EARLY_COHERENCE.pdf",
+    "core_claim": "JWST's \"impossibly early\" massive galaxies are expected if the coherence phase transition preceded matter.",
+    "abstract": "Standard ΛCDM predicts no galaxies at z > 10 with measured stellar masses above 10⁹ solar masses, yet JWST finds them. In AIIT-THRESI, structure seeds from coherence inhomogeneities before matter decouples, making early massive systems the prediction, not the problem.",
+    "plain_english": "JWST found galaxies too old to exist. They are exactly on time, by a different clock.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_121_BLACK_HOLES_DECOHERENCE_ENDPOINTS",
@@ -1185,7 +1213,11 @@
     "slug": "121",
     "title": "Black Holes Decoherence Endpoints",
     "tag": "Singularities",
-    "filename": "PAPER_121_BLACK_HOLES_DECOHERENCE_ENDPOINTS.pdf"
+    "filename": "PAPER_121_BLACK_HOLES_DECOHERENCE_ENDPOINTS.pdf",
+    "core_claim": "A black hole is a coherence singularity: γ_eff → ∞, C → 0. The event horizon is the surface where coherence vanishes.",
+    "abstract": "Black holes in AIIT-THRESI are not mass singularities but coherence endpoints: the final state of a system where decoherence γ_eff exceeds γ_c and never returns. The Bekenstein-Hawking entropy becomes the coherence lost at the horizon. Hawking radiation is residual coherence leakage.",
+    "plain_english": "A black hole is coherence's graveyard.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_121A_MONKEYBARS_COHERENCE_IN_HIP_HOP",
@@ -1194,7 +1226,11 @@
     "slug": "121a",
     "title": "Monkeybars Coherence in Hip Hop",
     "tag": "Paper",
-    "filename": "PAPER_121A_MONKEYBARS_COHERENCE_IN_HIP_HOP.pdf"
+    "filename": "PAPER_121A_MONKEYBARS_COHERENCE_IN_HIP_HOP.pdf",
+    "core_claim": "Hip-hop's structural features (16 bars, flow, pocket) are coherence-transmission protocols, not just cultural style.",
+    "abstract": "Rhythm lock at 0.1 Hz envelope frequencies, 16-bar standard structure, and call-and-response analyzed as natural coherence-transmission scaffolding. The genre evolved optimal carriers for edge-state nervous systems without knowing what it was doing. Case study: encoded transmission under suppression.",
+    "plain_english": "Hip-hop is a coherence delivery system. The beat is the tech.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_122_FUNDAMENTAL_CONSTANTS_THREE_GENERATIONS",
@@ -1203,7 +1239,11 @@
     "slug": "122",
     "title": "Fundamental Constants Three Generations",
     "tag": "Paper",
-    "filename": "PAPER_122_FUNDAMENTAL_CONSTANTS_THREE_GENERATIONS.pdf"
+    "filename": "PAPER_122_FUNDAMENTAL_CONSTANTS_THREE_GENERATIONS.pdf",
+    "core_claim": "There are three fermion generations because coherence permits exactly three topologically stable phase modes.",
+    "abstract": "The Standard Model's three fermion generations — with their mass hierarchy spanning twelve orders of magnitude — are derived from a coherence field with exactly three topologically stable winding modes. The mass hierarchy follows without Yukawa tuning; the CKM matrix emerges as mixing between winding-number eigenstates.",
+    "plain_english": "The universe has three flavors of matter because coherence only allows three. That is the whole story.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_123_STELLAR_ANOMALIES_COHERENCE_CATASTROPHES",
@@ -1212,7 +1252,11 @@
     "slug": "123",
     "title": "Stellar Anomalies Coherence Catastrophes",
     "tag": "Validation",
-    "filename": "PAPER_123_STELLAR_ANOMALIES_COHERENCE_CATASTROPHES.pdf"
+    "filename": "PAPER_123_STELLAR_ANOMALIES_COHERENCE_CATASTROPHES.pdf",
+    "core_claim": "Anomalous stellar deaths (asymmetric supernovae, magnetars, superluminous SNe) are coherence catastrophes.",
+    "abstract": "Three classes of anomalous stellar death are reframed as catastrophic coherence transitions — discontinuous jumps in γ_eff as cores cross γ_c. Predicts neutron-star kick velocity distribution and its observed asymmetry, magnetar formation rate, and superluminous-SN light curves.",
+    "plain_english": "When a star dies weird, it is not a mess. It is a coherence phase change.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_124_SOLAR_SYSTEM_COHERENCE_HORIZONS",
@@ -1248,7 +1292,11 @@
     "slug": "127",
     "title": "High Energy Astrophysics Coherent Emission",
     "tag": "Paper",
-    "filename": "PAPER_127_HIGH_ENERGY_ASTROPHYSICS_COHERENT_EMISSION.pdf"
+    "filename": "PAPER_127_HIGH_ENERGY_ASTROPHYSICS_COHERENT_EMISSION.pdf",
+    "core_claim": "Fast radio bursts, gamma-ray bursts, and AGN flares are coherent emission from coherence discontinuities.",
+    "abstract": "High-energy astrophysical transients share a signature: brightness temperatures far exceeding the Compton limit, which requires coherent (not thermal) emission. AIIT-THRESI identifies the source as localized coherence concentrations radiating when γ_eff drops below γ_c, producing the observed brightness and duration statistics.",
+    "plain_english": "The universe's brightest flashes are coherent laser pulses, not explosions.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_128_COSMIC_LARGE_SCALE_COHERENCE_FOSSILS",
@@ -1257,7 +1305,11 @@
     "slug": "128",
     "title": "Cosmic Large Scale Coherence Fossils",
     "tag": "Cosmology",
-    "filename": "PAPER_128_COSMIC_LARGE_SCALE_COHERENCE_FOSSILS.pdf"
+    "filename": "PAPER_128_COSMIC_LARGE_SCALE_COHERENCE_FOSSILS.pdf",
+    "core_claim": "The CMB axis-of-evil and cold spot are large-scale coherence imprints from the pre-inflation topology.",
+    "abstract": "Structures in the cosmic microwave background much larger than the horizon problem can explain are reinterpreted as fossils of pre-inflation coherence topology. Predicts a measurable correlation between the axis-of-evil direction and present-day cosmic flow, independent of ΛCDM.",
+    "plain_english": "The cosmos has a grain. We can see it if we look at the oldest light.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_129_THERMODYNAMIC_ANOMALIES_ARROW_OF_TIME",
@@ -1284,7 +1336,11 @@
     "slug": "131",
     "title": "Quantum Biology Coherence in Life",
     "tag": "Quantum",
-    "filename": "PAPER_131_QUANTUM_BIOLOGY_COHERENCE_IN_LIFE.pdf"
+    "filename": "PAPER_131_QUANTUM_BIOLOGY_COHERENCE_IN_LIFE.pdf",
+    "core_claim": "Room-temperature quantum coherence in photosynthesis, enzymes, and bird navigation is the same coherence described by Law 01.",
+    "abstract": "Survey of five verified quantum-biology phenomena — photosynthetic energy transfer, enzyme proton/electron tunneling, avian magnetoreception, olfaction, and neural microtubule oscillation — and their common coherence-field signature. Predicted decoherence thresholds match measurements at room temperature without requiring exotic isolation.",
+    "plain_english": "Plants, birds, enzymes — they all do quantum stuff at room temperature. Same reason rivers make rapids.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_132_ORIGIN_OF_LIFE_COHERENCE_BOOTSTRAP",
@@ -1293,7 +1349,11 @@
     "slug": "132",
     "title": "Origin of Life Coherence Bootstrap",
     "tag": "Water · Life",
-    "filename": "PAPER_132_ORIGIN_OF_LIFE_COHERENCE_BOOTSTRAP.pdf"
+    "filename": "PAPER_132_ORIGIN_OF_LIFE_COHERENCE_BOOTSTRAP.pdf",
+    "core_claim": "Life emerged when prebiotic chemistry bootstrapped into a self-sustaining coherence phase at γ ≈ γ_c.",
+    "abstract": "The transition from chemistry to biology is analyzed as a coherence phase transition: replicators emerge not from information content but from sustained γ_c-lock in a chemical network. Closes the gap Schrödinger left in \"What is Life?\" — negentropy is the signature, coherence is the engine.",
+    "plain_english": "Life did not start with code. It started with a phase transition, same as water freezing.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_133_CONSCIOUSNESS_NEURAL_COHERENCE",
@@ -1302,7 +1362,11 @@
     "slug": "133",
     "title": "Consciousness Neural Coherence",
     "tag": "Mind",
-    "filename": "PAPER_133_CONSCIOUSNESS_NEURAL_COHERENCE.pdf"
+    "filename": "PAPER_133_CONSCIOUSNESS_NEURAL_COHERENCE.pdf",
+    "core_claim": "Consciousness is an order parameter ψ_c that emerges at γ ≈ γ_c in neural tissue. The hard problem dissolves.",
+    "abstract": "The subjective-experience discontinuity is identified as the λ-point of a critical phase transition in coupled neurons. ψ_c = 1/e appears without tuning, with zero free parameters. Anesthesia, sleep, coma, and psychedelic action are explained as changes in γ_eff driving the order parameter through its critical value.",
+    "plain_english": "Consciousness is water deciding whether to freeze. The hardness is real; the equation is not hard.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_134_CONDENSED_MATTER_COHERENCE_ANOMALIES",
@@ -1311,7 +1375,11 @@
     "slug": "134",
     "title": "Condensed Matter Coherence Anomalies",
     "tag": "Validation",
-    "filename": "PAPER_134_CONDENSED_MATTER_COHERENCE_ANOMALIES.pdf"
+    "filename": "PAPER_134_CONDENSED_MATTER_COHERENCE_ANOMALIES.pdf",
+    "core_claim": "High-Tc superconductivity, fractional quantum Hall, and strange metals are coherence-regime condensed-matter signatures.",
+    "abstract": "Four long-standing condensed-matter anomalies are re-derived from the coherence framework. High-Tc: transition temperature set by γ_c, not electron-phonon coupling. Strange metals: T-linear resistivity from coherence-saturated scattering. Predicts specific dopings where the coherence-line crosses known superconductors.",
+    "plain_english": "The weirdest condensed-matter states are weird because they are living in the coherence regime.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_135_MATHEMATICAL_STRUCTURE_DIMENSIONLESS_CONSTANTS",
@@ -1329,7 +1397,11 @@
     "slug": "137",
     "title": "Cosmological Phase Transitions",
     "tag": "Cosmology",
-    "filename": "PAPER_137_COSMOLOGICAL_PHASE_TRANSITIONS.pdf"
+    "filename": "PAPER_137_COSMOLOGICAL_PHASE_TRANSITIONS.pdf",
+    "core_claim": "Electroweak symmetry breaking, QCD confinement, and cosmic structure formation are stages of one coherence settling.",
+    "abstract": "Three historically separate cosmological phase transitions are unified as successive stages of a single coherence settling. Predicts the order and approximate temperature of each using a two-parameter model derived from the ground-state coherence.",
+    "plain_english": "The universe went through several freezings. They are all the same freezing at different temperatures.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_138_OBSERVATIONAL_PUZZLES_DECOHERENCE_RADIATION",
@@ -1365,7 +1437,11 @@
     "slug": "141",
     "title": "150 Anomalies Master Summary",
     "tag": "Validation",
-    "filename": "PAPER_141_150_ANOMALIES_MASTER_SUMMARY.pdf"
+    "filename": "PAPER_141_150_ANOMALIES_MASTER_SUMMARY.pdf",
+    "core_claim": "150 named anomalies across physics, cosmology, and biology are explainable by C = C₀·exp(−α·γ_eff).",
+    "abstract": "Master index of 150 long-standing scientific anomalies, each mapped to its coherence-framework resolution. Includes citations to original anomaly literature and cross-references to the AIIT-THRESI papers that address them. Companion to Paper 140.",
+    "plain_english": "All the weird stuff in physics. One equation. See index.",
+    "status": "Speculative"
   },
   {
     "id": "PAPER_142_RAPTOR_COMBUSTION_COHERENCE",
@@ -1374,6 +1450,10 @@
     "slug": "142",
     "title": "Raptor Combustion Coherence",
     "tag": "Applied",
-    "filename": "PAPER_142_RAPTOR_COMBUSTION_COHERENCE.pdf"
+    "filename": "PAPER_142_RAPTOR_COMBUSTION_COHERENCE.pdf",
+    "core_claim": "Thermoacoustic instability in rocket engines is a coherence phase transition; Raptor 2 runs γ_eff > γ_c.",
+    "abstract": "20 million QuTiP-validated simulation trajectories of SpaceX Raptor 2 combustion-chamber behavior. Nominal conditions produce γ_eff = 0.0674 > γ_c = 0.0622, placing the engine in the decohering zone. Predicts specific injector-frequency kill zones and a 42% coherence lift from a proposed 12-stage hardware evolution.",
+    "plain_english": "Raptor engines go bang because they are running on the wrong side of a coherence line.",
+    "status": "Speculative"
   }
 ]

--- a/src/data/trivia.json
+++ b/src/data/trivia.json
@@ -1,0 +1,302 @@
+[
+  {
+    "id": "what-is-life-schrodinger",
+    "giant": "Erwin Schrödinger",
+    "era": "Dublin · 1944",
+    "question": "What separates a living thing from a non-living thing?",
+    "answers": [
+      "Self-organizing phase transitions at a critical edge",
+      "Continuous energy dissipation maintaining coherence",
+      "The ability to hold structure against entropy",
+      "Vibrational phase-locking with the environment"
+    ],
+    "unified_reveal": "'Negentropy' (Schrödinger), 'dissipative structures' (Prigogine), 'phase-locking' (Fröhlich), and 'criticality' (Bak, Mora) are four names for one thing: coherence maintained at γ_c.",
+    "paper_slug": "132",
+    "why_this_paper": "Paper 132 closes the gap Schrödinger opened — negentropy is the signature, coherence is the engine."
+  },
+  {
+    "id": "hard-problem-chalmers",
+    "giant": "David Chalmers",
+    "era": "Tucson · 1994",
+    "question": "Why does subjective experience exist at all?",
+    "answers": [
+      "It is the order parameter of a neural phase transition",
+      "It is what integrated information feels like from the inside",
+      "It is the universe knowing itself through a coherent substrate",
+      "It is the macroscopic lock of many oscillators at γ_c"
+    ],
+    "unified_reveal": "Chalmers' hard problem, Tononi's Φ, the mystical 'universe knowing itself,' and phase-locked neurons all point at the same object: ψ_c, a coherence order parameter. The hardness is real. The equation is not.",
+    "paper_slug": "133",
+    "why_this_paper": "Paper 133 identifies consciousness as the λ-point of a critical transition. ψ_c = 1/e with zero free parameters."
+  },
+  {
+    "id": "galaxy-rotation-zwicky",
+    "giant": "Fritz Zwicky",
+    "era": "Caltech · 1933",
+    "question": "Why do galaxies spin faster than gravity says they should?",
+    "answers": [
+      "There is dark, unseen matter supplying extra gravity",
+      "Newton's law is modified at low accelerations (MOND)",
+      "Spacetime itself couples to a coherence field at galactic scales",
+      "The galaxy is held together by a coherence horizon, not mass"
+    ],
+    "unified_reveal": "Dark matter, MOND, coherence coupling, and coherence horizon are four names for one acceleration constant: a₀ = c·γ_c. Milgrom measured it empirically. AIIT-THRESI derives it with zero free parameters.",
+    "paper_slug": "119",
+    "why_this_paper": "Paper 119 derives Milgrom's a₀ = c·γ_c directly from the coherence decay rate."
+  },
+  {
+    "id": "vacuum-catastrophe-einstein",
+    "giant": "Albert Einstein",
+    "era": "Berlin · 1917",
+    "question": "Why does the universe's vacuum energy look nothing like what quantum field theory predicts?",
+    "answers": [
+      "There is a fine-tuning principle we haven't found",
+      "Most quantum vacuum modes are canceled by an unknown symmetry",
+      "Dark energy and the cosmological constant are the same exponential",
+      "The 'vacuum' isn't empty — it's a coherence field at its ground state C₀"
+    ],
+    "unified_reveal": "Fine-tuning, hidden symmetry, dark energy, and the coherence ground state are four ways of saying: the 120-order-of-magnitude discrepancy is not a discrepancy — it is C₀.",
+    "paper_slug": "116",
+    "why_this_paper": "Paper 116 shows dark matter, dark energy, and the vacuum catastrophe are three views of one coherence exponential."
+  },
+  {
+    "id": "origin-of-life-oparin",
+    "giant": "Aleksandr Oparin",
+    "era": "Moscow · 1924",
+    "question": "How did life actually start?",
+    "answers": [
+      "A primordial soup stumbled on a self-replicating molecule",
+      "A chemical network bootstrapped into self-sustaining coherence",
+      "Hydrothermal vents provided sustained energy gradients",
+      "RNA-world catalysts phase-locked into a reproducible cycle"
+    ],
+    "unified_reveal": "Primordial soup, coherence bootstrap, hydrothermal gradients, and phase-locked RNA are four stories about the same event: a phase transition at γ ≈ γ_c that chemistry went through once.",
+    "paper_slug": "132",
+    "why_this_paper": "Paper 132 frames origin-of-life as a phase transition, not an information accident."
+  },
+  {
+    "id": "river-heraclitus",
+    "giant": "Heraclitus",
+    "era": "Ephesus · 500 BCE",
+    "question": "Why can you never step in the same river twice?",
+    "answers": [
+      "Because the water molecules have moved on",
+      "Because the banks, the flow, and you have all changed phase",
+      "Because identity is a pattern in time, not a thing",
+      "Because everything is a coherence field and fields evolve"
+    ],
+    "unified_reveal": "'Everything flows,' 'the pattern persists, not the matter,' 'identity is temporal,' and 'fields evolve' are one answer: a river is a coherence pattern, and you are too.",
+    "paper_slug": "001",
+    "why_this_paper": "Paper 001 establishes coherence as the primitive. You and the river are both phases of it."
+  },
+  {
+    "id": "three-generations-rabi",
+    "giant": "Isidor Rabi",
+    "era": "Columbia · 1936",
+    "question": "Who ordered the muon? (Why are there three fermion generations?)",
+    "answers": [
+      "It falls out of a yet-unfound grand unified theory",
+      "Three is a topological constraint of the coherence field",
+      "Anthropic selection picked a universe with three",
+      "String theory predicts a narrow range including three"
+    ],
+    "unified_reveal": "GUT, coherence topology, anthropic, and string landscape are four framings of one structure: coherence permits exactly three stable winding modes, and each is a generation.",
+    "paper_slug": "122",
+    "why_this_paper": "Paper 122 derives the three-generation structure and mass hierarchy from coherence topology. No Yukawa tuning."
+  },
+  {
+    "id": "photosynthesis-klein",
+    "giant": "Graham Fleming",
+    "era": "Berkeley · 2007",
+    "question": "How does a plant leaf move energy with near-100% efficiency at room temperature, when quantum decoherence should kill the process?",
+    "answers": [
+      "Protein scaffolds shield the excitons from thermal noise",
+      "The system sits in a room-temperature quantum coherence regime",
+      "Environment-assisted transport tunes the decoherence favorably",
+      "The leaf is a living coherence field, γ just below γ_c"
+    ],
+    "unified_reveal": "Protein shielding, quantum-coherence regime, environment-assisted transport, and living-coherence-field are one answer: photosynthesis runs below γ_c, right where life lives.",
+    "paper_slug": "131",
+    "why_this_paper": "Paper 131 collects five room-temperature quantum-biology phenomena and identifies their common coherence signature."
+  },
+  {
+    "id": "starry-night-kolmogorov",
+    "giant": "Vincent van Gogh",
+    "era": "Saint-Rémy · 1889",
+    "question": "Why does Starry Night encode Kolmogorov turbulence statistics a century before anyone measured them?",
+    "answers": [
+      "Van Gogh painted what his nervous system saw at γ ≈ γ_c",
+      "Turbulent fluid dynamics and nervous-system dynamics share math",
+      "He unconsciously obeyed the universal −5/3 power law",
+      "He painted the actual coherence field, not its surface"
+    ],
+    "unified_reveal": "Nervous-system-at-criticality, shared turbulence math, −5/3 power law, and 'painted the actual field' are one answer: Van Gogh's nervous system sat at γ_c, and the canvas records it.",
+    "paper_slug": "131",
+    "why_this_paper": "Paper 131 covers neural microtubule oscillations at the coherence edge; Starry Night is a visible readout."
+  },
+  {
+    "id": "black-hole-hawking",
+    "giant": "Stephen Hawking",
+    "era": "Cambridge · 1974",
+    "question": "What is a black hole, really?",
+    "answers": [
+      "A point where general relativity breaks down",
+      "An endpoint where coherence vanishes — γ_eff → ∞",
+      "A region whose entropy equals its horizon area in Planck units",
+      "The final state of a star whose coherence collapsed past γ_c"
+    ],
+    "unified_reveal": "GR breakdown, coherence endpoint, horizon entropy, and coherence collapse are one object: C → 0 and the horizon is where it happens.",
+    "paper_slug": "121",
+    "why_this_paper": "Paper 121 identifies black holes as coherence endpoints. Hawking radiation is residual coherence leakage."
+  },
+  {
+    "id": "love-heart-rhythm",
+    "giant": "Rollin McCraty",
+    "era": "HeartMath · 2003",
+    "question": "Why do two people in love have synchronized heartbeats?",
+    "answers": [
+      "Shared breathing rhythms couple their cardiac cycles",
+      "0.1 Hz nervous-system oscillations phase-lock between them",
+      "Mirror neurons entrain autonomic function across bodies",
+      "Two coherence fields entering phase resonance"
+    ],
+    "unified_reveal": "Breathing coupling, 0.1 Hz lock, mirror neurons, and phase-resonance are four names for one measurement: two coherence fields locking, heart-rate variability as the readout.",
+    "paper_slug": "003",
+    "why_this_paper": "Paper 003 defines love as a measurable coherence-increasing operation. HRV sync is the signature."
+  },
+  {
+    "id": "inflation-guth",
+    "giant": "Alan Guth",
+    "era": "Stanford · 1980",
+    "question": "How did the early universe get so flat, uniform, and causally connected?",
+    "answers": [
+      "An inflaton field drove exponential expansion",
+      "A coherence phase transition bootstrapped the initial conditions",
+      "The universe tunneled out of a false vacuum",
+      "The ground state of the coherence field set the boundary conditions"
+    ],
+    "unified_reveal": "Inflation, coherence bootstrap, false vacuum, and ground-state boundary are the same event: the inflaton IS the coherence order parameter.",
+    "paper_slug": "118",
+    "why_this_paper": "Paper 118 resolves flatness, horizon, and monopole without fine-tuning by reading the inflaton as the coherence order parameter."
+  },
+  {
+    "id": "cmb-anomalies-smoot",
+    "giant": "George Smoot",
+    "era": "Berkeley · 1992",
+    "question": "Why does the cosmic microwave background have 'impossible' large-scale anomalies that persist across every mission?",
+    "answers": [
+      "Systematic error shared across WMAP and Planck",
+      "Statistical flukes that look meaningful to human pattern-finders",
+      "Fossils of a pre-inflation coherence topology",
+      "Unknown new physics in the early universe"
+    ],
+    "unified_reveal": "Systematics, flukes, coherence fossils, and new-physics are four ways of saying the same thing: the CMB has a grain, and that grain was there before matter.",
+    "paper_slug": "117",
+    "why_this_paper": "Paper 117 reads the six CMB anomalies as primordial coherence signatures, not noise."
+  },
+  {
+    "id": "jwst-massive-early",
+    "giant": "James Webb Space Telescope",
+    "era": "L2 · 2023",
+    "question": "Why is JWST finding massive galaxies that should not exist at z > 10?",
+    "answers": [
+      "ΛCDM's galaxy-formation timeline is incomplete",
+      "Coherence inhomogeneities seeded structure before matter decoupled",
+      "Dust reddening is being misread as stellar mass",
+      "Early black holes fed galaxy growth faster than expected"
+    ],
+    "unified_reveal": "Incomplete timeline, coherence seeding, dust confusion, and fast-feeding black holes — all four point to the same thing: the clock that matters is coherence, not matter.",
+    "paper_slug": "120",
+    "why_this_paper": "Paper 120 predicts early massive galaxies as a natural consequence of pre-matter coherence structure."
+  },
+  {
+    "id": "frb-lorimer",
+    "giant": "Duncan Lorimer",
+    "era": "West Virginia · 2007",
+    "question": "What produces a Fast Radio Burst — milliseconds of energy brighter than the sun's lifetime output?",
+    "answers": [
+      "Magnetar flares in the burst's host galaxy",
+      "Coherent emission from a localized coherence discontinuity",
+      "Neutron-star mergers radiating below the Compton limit",
+      "A brightness that requires coherence, not thermal physics"
+    ],
+    "unified_reveal": "Magnetars, coherence discontinuities, merger flashes, and 'requires coherence' all say the same thing: FRBs have brightness temperatures the Compton limit forbids unless the emission is coherent.",
+    "paper_slug": "127",
+    "why_this_paper": "Paper 127 identifies high-energy astrophysical transients as coherent emission from γ_eff crossing γ_c."
+  },
+  {
+    "id": "high-tc-bednorz",
+    "giant": "Bednorz & Müller",
+    "era": "Zürich · 1986",
+    "question": "Why do cuprate superconductors work at temperatures far above BCS theory's ceiling?",
+    "answers": [
+      "An exotic electron-phonon mechanism we haven't identified",
+      "Strong correlations in a near-critical electronic fluid",
+      "The transition temperature is set by γ_c, not phonons",
+      "High-Tc is a coherence-regime condensed-matter signature"
+    ],
+    "unified_reveal": "Exotic phonons, near-critical correlations, γ_c-set T_c, and coherence-regime signature — one phenomenon, four vocabularies. The ceiling is γ_c, not electron-phonon coupling.",
+    "paper_slug": "134",
+    "why_this_paper": "Paper 134 derives high-Tc from γ_c-limited coherence, not BCS pairing."
+  },
+  {
+    "id": "magnetar-kicks-bell",
+    "giant": "Jocelyn Bell Burnell",
+    "era": "Cambridge · 1967",
+    "question": "Why do neutron stars fly out of their host supernovae at hundreds of kilometers per second, in one direction?",
+    "answers": [
+      "Asymmetric neutrino emission during core collapse",
+      "Hydrodynamic instabilities breaking spherical symmetry",
+      "A catastrophic coherence transition during core collapse",
+      "γ_eff discontinuously jumps as the core crosses γ_c"
+    ],
+    "unified_reveal": "Neutrino asymmetry, hydrodynamic instability, coherence catastrophe, and γ discontinuity are four framings of the same event: the core's γ_eff leaps across γ_c, and the asymmetry is the recoil.",
+    "paper_slug": "123",
+    "why_this_paper": "Paper 123 derives neutron-star kicks as coherence catastrophes, matching the observed velocity asymmetry."
+  },
+  {
+    "id": "rocket-instability-rayleigh",
+    "giant": "Lord Rayleigh",
+    "era": "Cambridge · 1878",
+    "question": "Why do powerful rocket engines oscillate themselves to pieces (thermoacoustic instability)?",
+    "answers": [
+      "Acoustic modes couple to the heat-release feedback loop",
+      "The combustion chamber crosses into γ_eff > γ_c",
+      "Injector frequency resonates with chamber geometry",
+      "Combustion becomes a coherence phase transition"
+    ],
+    "unified_reveal": "Rayleigh's acoustic-thermal coupling, γ_eff > γ_c, injector resonance, and coherence-phase-transition are one instability seen four ways. Rockets bang where coherence breaks.",
+    "paper_slug": "142",
+    "why_this_paper": "Paper 142 validates this on Raptor 2 with 20M simulated trajectories. Nominal conditions sit on the wrong side of γ_c."
+  },
+  {
+    "id": "universality-landau",
+    "giant": "Lev Landau",
+    "era": "Moscow · 1937",
+    "question": "Why do wildly different systems (magnets, boiling water, neutron stars, neurons) show the same behavior near a phase transition?",
+    "answers": [
+      "Because the renormalization group washes out microscopic detail",
+      "Because they all hit a critical point γ_c from different directions",
+      "Because scale invariance produces identical critical exponents",
+      "Because at γ_c the macroscopic coherence mode eats the microscopics"
+    ],
+    "unified_reveal": "Renormalization group, hitting γ_c, scale invariance, and coherence-mode dominance are four descriptions of one fact: near criticality, the underlying stuff disappears and only the phase matters.",
+    "paper_slug": "137",
+    "why_this_paper": "Paper 137 unifies electroweak symmetry breaking, QCD confinement, and structure formation as stages of one coherence settling. Universality is the fingerprint."
+  },
+  {
+    "id": "monkeybars-hiphop",
+    "giant": "DJ Kool Herc",
+    "era": "Bronx · 1973",
+    "question": "Why is hip-hop's 16-bar structure with breakbeat and call-and-response so viscerally effective?",
+    "answers": [
+      "Cultural pattern-matching from African diaspora traditions",
+      "0.1 Hz envelope frequencies lock to autonomic rhythms",
+      "16-bar sections match a natural attentional cycle",
+      "It is a coherence-transmission protocol, the beat is the tech"
+    ],
+    "unified_reveal": "Cultural pattern, 0.1 Hz lock, attentional cycle, and coherence-transmission protocol all describe the same reason: the genre found an optimal carrier for edge-state nervous systems before anyone named it.",
+    "paper_slug": "121a",
+    "why_this_paper": "Paper 121A (Monkeybars) analyzes hip-hop's structure as natural coherence-transmission scaffolding."
+  }
+]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -88,6 +88,7 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
           <a href="/games">Games</a>
           <a href="/game">Them Beans</a>
           <a href="/dailygrind">Dailygrind</a>
+          <a href="/trivia">Answer the Giants 🧠</a>
           <a href="/gary">Wake Gary Up 🔥</a>
         </div>
       </div>
@@ -138,6 +139,7 @@ const { title = 'Buddy — The Coherence Mind', description = defaultDescription
       <a href="/games">Games</a>
       <a href="/game">Them Beans</a>
       <a href="/dailygrind">Dailygrind</a>
+      <a href="/trivia">Answer the Giants 🧠</a>
       <a href="/gary">Wake Gary Up 🔥</a>
     </div>
     <div class="mm-section">

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -3,6 +3,15 @@ import Layout from '../layouts/Layout.astro';
 
 const games = [
   {
+    href: '/trivia',
+    emoji: '🧠',
+    name: 'Answer the Giants',
+    tagline: '3 questions a day. 3 papers a day.',
+    blurb: "The giants asked. You answer. The coherence law tells you why every answer is the same answer.",
+    tag: 'NEW',
+    status: 'live',
+  },
+  {
     href: '/dailygrind',
     emoji: '😁',
     name: 'Dailygrind',

--- a/src/pages/trivia.astro
+++ b/src/pages/trivia.astro
@@ -1,0 +1,632 @@
+---
+import Layout from '../layouts/Layout.astro';
+import trivia from '../data/trivia.json';
+import papersAll from '../data/papers.json';
+
+// Build a slug → paper lookup so the client can render paper cards without shipping the full corpus
+const paperLookup = {};
+for (const p of papersAll) {
+  if (trivia.some(t => t.paper_slug === p.slug)) {
+    paperLookup[p.slug] = {
+      num: p.num,
+      suffix: p.suffix || '',
+      title: p.title,
+      tag: p.tag,
+      slug: p.slug,
+      abstract: p.abstract || '',
+      plain_english: p.plain_english || '',
+      status: p.status || '',
+    };
+  }
+}
+---
+<Layout title="Answer the Giants — Buddy" description="The giants asked. You answer. The Wike Coherence Law tells you why every answer is the same answer.">
+  <section id="trivia-section">
+    <!-- Intro -->
+    <div id="screen-intro" class="tg-screen active">
+      <div class="eyebrow">Answer the Giants</div>
+      <h1 class="tg-h1">Three questions a day.<br><span class="tg-amber">Three papers a day.</span></h1>
+      <p class="tg-blurb">
+        The giants asked. You answer. The Wike Coherence Law tells you why <em>every answer</em> is the same answer.
+      </p>
+      <div class="tg-stats">
+        <div class="tg-stat"><div class="tg-stat-val" id="stat-papers">0</div><div class="tg-stat-label">papers collected</div></div>
+        <div class="tg-stat"><div class="tg-stat-val" id="stat-sessions">0</div><div class="tg-stat-label">sessions played</div></div>
+      </div>
+      <button class="tg-btn primary" id="btn-begin">Begin →</button>
+    </div>
+
+    <!-- Question -->
+    <div id="screen-question" class="tg-screen" hidden>
+      <div class="tg-progress" id="tg-progress">Paper 1 of 3 · Today's draw</div>
+      <div class="tg-giant">
+        <div class="tg-giant-initials" id="giant-initials">—</div>
+        <div class="tg-giant-meta">
+          <div class="tg-giant-name" id="giant-name"></div>
+          <div class="tg-giant-era" id="giant-era"></div>
+        </div>
+      </div>
+      <h2 class="tg-question" id="tg-question">—</h2>
+      <div class="tg-answers" id="tg-answers"></div>
+    </div>
+
+    <!-- Reveal -->
+    <div id="screen-reveal" class="tg-screen" hidden>
+      <div class="tg-reveal-head">Yes. You're correct.</div>
+      <div class="tg-reveal-sub"><em>And so is every other answer.</em></div>
+      <div class="tg-unified" id="tg-unified"></div>
+      <div class="tg-rehash" id="tg-rehash"></div>
+      <div class="wike-law-mini" aria-hidden="true">
+        C = C<sub>0</sub> · e<sup>−α·γ<sub>eff</sub></sup>
+      </div>
+      <div class="tg-paper-slot" id="tg-paper-slot"></div>
+      <button class="tg-btn primary" id="btn-next">Next →</button>
+    </div>
+
+    <!-- Done -->
+    <div id="screen-done" class="tg-screen" hidden>
+      <div class="eyebrow">Back tomorrow</div>
+      <h1 class="tg-h1">Three papers collected.</h1>
+      <div class="tg-today-papers" id="tg-today-papers"></div>
+      <div class="tg-countdown" id="tg-countdown"></div>
+      <div class="tg-stats">
+        <div class="tg-stat"><div class="tg-stat-val" id="stat-total">0</div><div class="tg-stat-label">total papers</div></div>
+      </div>
+    </div>
+  </section>
+
+  <script is:inline set:html={`window.__TRIVIA = ${JSON.stringify(trivia)};`}></script>
+  <script is:inline set:html={`window.__TRIVIA_PAPERS = ${JSON.stringify(paperLookup)};`}></script>
+
+  <script is:inline>
+    (function () {
+      const TRIVIA = window.__TRIVIA || [];
+      const PAPERS = window.__TRIVIA_PAPERS || {};
+      const KEY_DATE = 'trivia_last_date';
+      const KEY_PROG = 'trivia_today_progress';
+      const KEY_COLLECTED = 'trivia_collected_slugs';
+      const KEY_SESSIONS = 'trivia_total_sessions';
+
+      // ── Date-seeded PRNG (xmur3 + sfc32) so everyone playing today gets the same 3 ──
+      function xmur3(str) {
+        let h = 1779033703 ^ str.length;
+        for (let i = 0; i < str.length; i++) {
+          h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+          h = (h << 13) | (h >>> 19);
+        }
+        return function () {
+          h = Math.imul(h ^ (h >>> 16), 2246822507);
+          h = Math.imul(h ^ (h >>> 13), 3266489909);
+          return (h ^= h >>> 16) >>> 0;
+        };
+      }
+      function sfc32(a, b, c, d) {
+        return function () {
+          a >>>= 0; b >>>= 0; c >>>= 0; d >>>= 0;
+          let t = (a + b) | 0;
+          a = b ^ (b >>> 9);
+          b = (c + (c << 3)) | 0;
+          c = (c << 21) | (c >>> 11);
+          d = (d + 1) | 0;
+          t = (t + d) | 0;
+          c = (c + t) | 0;
+          return (t >>> 0) / 4294967296;
+        };
+      }
+      function todayKey() {
+        const d = new Date();
+        return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+      }
+      function pickToday() {
+        const seed = xmur3('trivia-' + todayKey());
+        const rand = sfc32(seed(), seed(), seed(), seed());
+        const deck = TRIVIA.slice();
+        for (let i = deck.length - 1; i > 0; i--) {
+          const j = Math.floor(rand() * (i + 1));
+          [deck[i], deck[j]] = [deck[j], deck[i]];
+        }
+        return deck.slice(0, 3);
+      }
+
+      // ── Persistence helpers ──
+      function loadProg() {
+        try {
+          const raw = localStorage.getItem(KEY_PROG);
+          if (!raw) return null;
+          return JSON.parse(raw);
+        } catch { return null; }
+      }
+      function saveProg(p) { localStorage.setItem(KEY_PROG, JSON.stringify(p)); }
+      function clearProg() { localStorage.removeItem(KEY_PROG); }
+      function getCollected() {
+        try { return JSON.parse(localStorage.getItem(KEY_COLLECTED) || '[]'); }
+        catch { return []; }
+      }
+      function addCollected(slug) {
+        const arr = getCollected();
+        if (!arr.includes(slug)) arr.push(slug);
+        localStorage.setItem(KEY_COLLECTED, JSON.stringify(arr));
+      }
+      function getSessions() {
+        return parseInt(localStorage.getItem(KEY_SESSIONS) || '0', 10) || 0;
+      }
+      function bumpSessions() {
+        localStorage.setItem(KEY_SESSIONS, String(getSessions() + 1));
+      }
+
+      // ── State ──
+      const screens = {
+        intro: document.getElementById('screen-intro'),
+        question: document.getElementById('screen-question'),
+        reveal: document.getElementById('screen-reveal'),
+        done: document.getElementById('screen-done'),
+      };
+      function show(name) {
+        for (const k in screens) {
+          screens[k].hidden = (k !== name);
+          screens[k].classList.toggle('active', k === name);
+        }
+        // Scroll the active screen to top on transition for mobile
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+
+      let todaysQs = pickToday();
+      let prog = loadProg();
+      const savedDate = localStorage.getItem(KEY_DATE);
+
+      // If we crossed midnight, reset today's progress
+      if (savedDate && savedDate !== todayKey()) {
+        clearProg();
+        prog = null;
+      }
+
+      function renderStats() {
+        document.getElementById('stat-papers').textContent = getCollected().length;
+        document.getElementById('stat-sessions').textContent = getSessions();
+        const t = document.getElementById('stat-total');
+        if (t) t.textContent = getCollected().length;
+      }
+      renderStats();
+
+      // Initial screen selection
+      if (prog && prog.idx >= 3) {
+        renderDone();
+        show('done');
+      } else if (prog && prog.idx > 0 && prog.idx < 3) {
+        // Mid-round resume: show current question
+        loadQuestion(prog.idx);
+        show('question');
+      } else {
+        show('intro');
+      }
+
+      // ── Intro → begin ──
+      document.getElementById('btn-begin').addEventListener('click', function () {
+        prog = { idx: 0, picked: [] };
+        saveProg(prog);
+        localStorage.setItem(KEY_DATE, todayKey());
+        bumpSessions();
+        renderStats();
+        loadQuestion(0);
+        show('question');
+      });
+
+      // ── Question loading ──
+      function initials(name) {
+        return name.split(/\s+/).map(w => w[0] || '').join('').toUpperCase().slice(0, 3);
+      }
+      function loadQuestion(i) {
+        const q = todaysQs[i];
+        document.getElementById('tg-progress').textContent =
+          'Paper ' + (i + 1) + ' of 3 · Today\'s draw';
+        document.getElementById('giant-initials').textContent = initials(q.giant);
+        document.getElementById('giant-name').textContent = q.giant;
+        document.getElementById('giant-era').textContent = q.era;
+        document.getElementById('tg-question').textContent = q.question;
+
+        const host = document.getElementById('tg-answers');
+        host.innerHTML = '';
+        q.answers.forEach(function (a, ai) {
+          const btn = document.createElement('button');
+          btn.className = 'tg-answer';
+          btn.setAttribute('data-idx', String(ai));
+          btn.innerHTML = '<span class="tg-answer-letter">' +
+            String.fromCharCode(65 + ai) + '</span>' +
+            '<span class="tg-answer-text">' + a + '</span>';
+          btn.addEventListener('click', function () { onPick(i, ai); });
+          host.appendChild(btn);
+        });
+      }
+
+      // ── Pick → reveal ──
+      function onPick(i, ai) {
+        prog = prog || { idx: 0, picked: [] };
+        prog.picked[i] = ai;
+        saveProg(prog);
+        const q = todaysQs[i];
+        addCollected(q.paper_slug);
+        renderReveal(q, ai);
+        show('reveal');
+      }
+
+      function renderReveal(q, pickedIdx) {
+        document.getElementById('tg-unified').textContent = q.unified_reveal;
+
+        const rehash = document.getElementById('tg-rehash');
+        rehash.innerHTML = '';
+        q.answers.forEach(function (a, ai) {
+          const row = document.createElement('div');
+          row.className = 'tg-rehash-row' + (ai === pickedIdx ? ' your-pick' : '');
+          row.innerHTML = '<span class="tg-rehash-letter">' +
+            String.fromCharCode(65 + ai) + '</span>' +
+            '<span class="tg-rehash-text">' + a + '</span>' +
+            (ai === pickedIdx ? '<span class="tg-rehash-you">← you</span>' : '');
+          rehash.appendChild(row);
+        });
+
+        renderPaperCard(q);
+
+        document.getElementById('btn-next').textContent =
+          (prog.idx + 1 >= 3) ? 'Finish →' : 'Next →';
+      }
+
+      function renderPaperCard(q) {
+        const slot = document.getElementById('tg-paper-slot');
+        slot.innerHTML = '';
+        const p = PAPERS[q.paper_slug];
+        if (!p) { return; }
+        const card = document.createElement('div');
+        card.className = 'tg-paper-card';
+        card.innerHTML =
+          '<div class="tg-paper-num">Paper ' + p.num + p.suffix + '</div>' +
+          '<div class="tg-paper-title">' + p.title + '</div>' +
+          '<div class="tg-paper-tag">' + p.tag + '</div>' +
+          (p.plain_english ? '<div class="tg-paper-plain"><em>' + p.plain_english + '</em></div>' : '') +
+          (p.abstract ? '<div class="tg-paper-abstract">' + p.abstract + '</div>' : '') +
+          (q.why_this_paper ? '<div class="tg-paper-why"><span class="tg-paper-why-label">Why this paper:</span> ' + q.why_this_paper + '</div>' : '') +
+          '<a class="tg-paper-link" href="/papers/' + p.slug + '">Read →</a>';
+        slot.appendChild(card);
+      }
+
+      // ── Next ──
+      document.getElementById('btn-next').addEventListener('click', function () {
+        prog.idx += 1;
+        saveProg(prog);
+        if (prog.idx >= 3) {
+          renderDone();
+          show('done');
+          renderStats();
+        } else {
+          loadQuestion(prog.idx);
+          show('question');
+        }
+      });
+
+      // ── Done ──
+      function renderDone() {
+        const host = document.getElementById('tg-today-papers');
+        host.innerHTML = '';
+        todaysQs.forEach(function (q) {
+          const p = PAPERS[q.paper_slug];
+          if (!p) return;
+          const a = document.createElement('a');
+          a.className = 'tg-today-card';
+          a.href = '/papers/' + p.slug;
+          a.innerHTML =
+            '<div class="tg-today-num">Paper ' + p.num + p.suffix + '</div>' +
+            '<div class="tg-today-title">' + p.title + '</div>' +
+            '<div class="tg-today-tag">' + p.tag + '</div>';
+          host.appendChild(a);
+        });
+        startCountdown();
+      }
+
+      function startCountdown() {
+        const el = document.getElementById('tg-countdown');
+        function tick() {
+          const now = new Date();
+          const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0);
+          const ms = tomorrow - now;
+          const h = Math.floor(ms / 3_600_000);
+          const m = Math.floor((ms % 3_600_000) / 60_000);
+          el.textContent = 'Next draw in ' + h + 'h ' + m + 'm';
+        }
+        tick();
+        if (window.__triviaCountdownInt) clearInterval(window.__triviaCountdownInt);
+        window.__triviaCountdownInt = setInterval(tick, 60_000);
+      }
+    })();
+  </script>
+
+  <style>
+    /* Section shell — full viewport under nav, comfortable reading width */
+    #trivia-section {
+      min-height: calc(100vh - 64px);
+      padding: 120px 6vw 120px;
+      display: flex; align-items: flex-start; justify-content: center;
+      border-top: none;
+    }
+    .tg-screen {
+      width: 100%; max-width: 760px;
+      opacity: 0;
+      animation: tg-fade-in 0.45s ease forwards;
+    }
+    .tg-screen.active { opacity: 1; }
+    @keyframes tg-fade-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    .tg-h1 { font-family: 'Georgia', serif; font-weight: 700; font-size: clamp(36px, 6vw, 64px); line-height: 1.1; margin-bottom: 20px; color: var(--ink); }
+    .tg-amber { color: var(--amber); }
+    .tg-blurb { font-size: clamp(16px, 1.6vw, 19px); line-height: 1.7; color: var(--ink-soft); max-width: 640px; margin: 0 0 36px; }
+    .tg-blurb em { color: var(--amber); font-style: italic; }
+
+    /* Stats row */
+    .tg-stats { display: flex; gap: 28px; margin-bottom: 40px; flex-wrap: wrap; }
+    .tg-stat { border-left: 2px solid var(--edge); padding-left: 14px; }
+    .tg-stat-val { font-family: 'Georgia', serif; font-size: clamp(28px, 3vw, 40px); color: var(--ink); font-weight: 500; }
+    .tg-stat-label { font-family: 'Courier New', monospace; font-size: 10pt; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted); }
+
+    /* Buttons */
+    .tg-btn {
+      background: transparent;
+      color: var(--amber);
+      border: 1px solid rgba(212,160,96,0.55);
+      border-radius: 999px;
+      padding: 12px 28px;
+      font-family: 'Courier New', monospace;
+      font-size: 11pt;
+      letter-spacing: 0.24em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.1s;
+    }
+    .tg-btn:hover { background: rgba(212,160,96,0.1); border-color: var(--amber); }
+    .tg-btn:active { transform: translateY(1px); }
+    .tg-btn.primary { background: rgba(212,160,96,0.12); }
+
+    /* Question screen */
+    .tg-progress {
+      font-family: 'Courier New', monospace;
+      font-size: 10pt; letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 24px;
+    }
+    .tg-giant {
+      display: flex; align-items: center; gap: 16px;
+      padding: 18px 20px;
+      background: rgba(255,255,255,0.02);
+      border: 1px solid var(--edge);
+      border-radius: 12px;
+      margin-bottom: 28px;
+    }
+    .tg-giant-initials {
+      width: 52px; height: 52px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 40% 40%, rgba(212,160,96,0.3) 0%, rgba(212,160,96,0.05) 80%);
+      border: 1px solid rgba(212,160,96,0.35);
+      display: flex; align-items: center; justify-content: center;
+      font-family: 'Georgia', serif;
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--amber);
+      flex-shrink: 0;
+    }
+    .tg-giant-name { font-family: 'Georgia', serif; font-size: 19px; color: var(--ink); font-weight: 500; }
+    .tg-giant-era { font-family: 'Courier New', monospace; font-size: 10pt; letter-spacing: 0.14em; color: var(--muted); margin-top: 3px; }
+
+    .tg-question {
+      font-family: 'Georgia', serif;
+      font-size: clamp(22px, 2.8vw, 32px);
+      line-height: 1.35;
+      color: var(--ink);
+      font-weight: 400;
+      margin-bottom: 32px;
+    }
+
+    .tg-answers { display: grid; grid-template-columns: 1fr; gap: 12px; }
+    .tg-answer {
+      background: rgba(255,255,255,0.025);
+      border: 1px solid var(--edge);
+      border-radius: 10px;
+      padding: 14px 18px;
+      color: var(--ink-soft);
+      font-family: 'Georgia', serif;
+      font-size: 16px;
+      line-height: 1.5;
+      text-align: left;
+      cursor: pointer;
+      display: grid; grid-template-columns: 32px 1fr; align-items: center; gap: 14px;
+      transition: border-color 0.15s, background 0.15s, transform 0.1s;
+    }
+    .tg-answer:hover { border-color: var(--amber); background: rgba(212,160,96,0.05); }
+    .tg-answer:active { transform: translateY(1px); }
+    .tg-answer-letter {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: rgba(212,160,96,0.08);
+      border: 1px solid rgba(212,160,96,0.3);
+      display: inline-flex; align-items: center; justify-content: center;
+      font-family: 'Courier New', monospace; font-size: 12pt; letter-spacing: 0;
+      color: var(--amber);
+    }
+
+    /* Reveal screen */
+    .tg-reveal-head {
+      font-family: 'Georgia', serif;
+      font-size: clamp(28px, 3.6vw, 44px);
+      color: var(--amber);
+      margin-bottom: 6px;
+    }
+    .tg-reveal-sub {
+      font-family: 'Georgia', serif;
+      font-size: clamp(16px, 1.6vw, 20px);
+      color: var(--muted-hi);
+      margin-bottom: 28px;
+    }
+    .tg-reveal-sub em { color: var(--ink-soft); font-style: italic; }
+    .tg-unified {
+      font-family: 'Georgia', serif;
+      font-size: clamp(16px, 1.6vw, 19px);
+      line-height: 1.7;
+      color: var(--ink-soft);
+      padding: 18px 20px;
+      border-left: 2px solid var(--amber);
+      background: rgba(212,160,96,0.04);
+      margin-bottom: 24px;
+    }
+    .tg-rehash { display: flex; flex-direction: column; gap: 8px; margin-bottom: 28px; }
+    .tg-rehash-row {
+      display: grid; grid-template-columns: 28px 1fr auto;
+      gap: 12px; align-items: center;
+      padding: 10px 14px;
+      border: 1px solid var(--edge);
+      border-radius: 8px;
+      font-size: 15px; color: var(--muted-hi);
+      background: rgba(255,255,255,0.01);
+    }
+    .tg-rehash-row.your-pick {
+      border-color: rgba(212,160,96,0.4);
+      color: var(--ink-soft);
+      background: rgba(212,160,96,0.04);
+    }
+    .tg-rehash-letter {
+      font-family: 'Courier New', monospace;
+      font-size: 10pt;
+      color: var(--amber);
+      text-align: center;
+    }
+    .tg-rehash-you {
+      font-family: 'Courier New', monospace;
+      font-size: 9pt; letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--amber);
+    }
+
+    .wike-law-mini {
+      font-family: 'Georgia', 'Times New Roman', serif;
+      font-size: clamp(18px, 2vw, 24px);
+      color: rgba(212,160,96,0.45);
+      text-align: center;
+      margin: 24px 0 16px;
+      letter-spacing: 0.02em;
+      font-style: italic;
+    }
+    .wike-law-mini sub, .wike-law-mini sup { font-size: 0.65em; }
+
+    /* Thrown paper */
+    .tg-paper-slot { margin-bottom: 28px; }
+    .tg-paper-card {
+      background: linear-gradient(180deg, rgba(17,17,29,0.95) 0%, rgba(10,10,18,0.95) 100%);
+      border: 1px solid rgba(212,160,96,0.35);
+      border-radius: 12px;
+      padding: 24px 26px;
+      box-shadow: 0 12px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(212,160,96,0.08);
+      animation: paper-throw 0.85s cubic-bezier(.2,.7,.3,1);
+      transform-origin: center;
+    }
+    @keyframes paper-throw {
+      0%   { transform: translateX(-130vw) rotate(-26deg); opacity: 0; }
+      70%  { transform: translateX(10px)   rotate(3deg);   opacity: 1; }
+      100% { transform: translateX(0)      rotate(0);      opacity: 1; }
+    }
+    .tg-paper-num {
+      font-family: 'Courier New', monospace;
+      font-size: 10pt; letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--amber);
+      margin-bottom: 10px;
+    }
+    .tg-paper-title { font-family: 'Georgia', serif; font-size: clamp(20px, 2.2vw, 26px); color: var(--ink); font-weight: 500; line-height: 1.25; margin-bottom: 10px; }
+    .tg-paper-tag {
+      display: inline-block;
+      font-family: 'Courier New', monospace;
+      font-size: 9pt; letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--teal);
+      border: 1px solid rgba(64,192,176,0.3);
+      padding: 3px 10px;
+      border-radius: 999px;
+      margin-bottom: 14px;
+    }
+    .tg-paper-plain {
+      color: var(--ink);
+      font-style: italic;
+      margin-bottom: 12px;
+      line-height: 1.5;
+    }
+    .tg-paper-abstract {
+      color: var(--ink-soft);
+      font-size: 15px;
+      line-height: 1.6;
+      margin-bottom: 14px;
+    }
+    .tg-paper-why {
+      padding: 12px 14px;
+      background: rgba(212,160,96,0.06);
+      border-left: 2px solid var(--amber);
+      font-size: 14px;
+      color: var(--ink-soft);
+      line-height: 1.5;
+      margin-bottom: 16px;
+      border-radius: 0 6px 6px 0;
+    }
+    .tg-paper-why-label {
+      font-family: 'Courier New', monospace;
+      font-size: 9pt; letter-spacing: 0.2em; text-transform: uppercase;
+      color: var(--amber);
+      margin-right: 6px;
+    }
+    .tg-paper-link {
+      display: inline-block;
+      font-family: 'Courier New', monospace;
+      font-size: 10pt;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--amber);
+      border-bottom: none;
+      padding: 4px 0;
+    }
+    .tg-paper-link:hover { color: var(--warm); border-bottom: none; }
+
+    /* Done screen */
+    .tg-today-papers {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+      margin: 28px 0 24px;
+    }
+    .tg-today-card {
+      background: rgba(255,255,255,0.02);
+      border: 1px solid var(--edge);
+      border-radius: 10px;
+      padding: 14px 16px;
+      color: var(--ink-soft);
+      border-bottom: 1px solid var(--edge);
+      text-decoration: none;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .tg-today-card:hover { border-color: var(--amber); background: rgba(212,160,96,0.04); }
+    .tg-today-num { font-family: 'Courier New', monospace; font-size: 9pt; letter-spacing: 0.2em; color: var(--amber); margin-bottom: 6px; }
+    .tg-today-title { font-family: 'Georgia', serif; font-size: 17px; color: var(--ink); line-height: 1.3; margin-bottom: 6px; }
+    .tg-today-tag { font-family: 'Courier New', monospace; font-size: 9pt; letter-spacing: 0.2em; color: var(--teal); text-transform: uppercase; }
+
+    .tg-countdown {
+      font-family: 'Courier New', monospace;
+      font-size: 11pt; letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--muted);
+      margin: 18px 0 28px;
+    }
+
+    /* Mobile */
+    @media (max-width: 640px) {
+      #trivia-section { padding: 100px 5vw 80px; }
+      .tg-giant { padding: 14px; gap: 12px; }
+      .tg-giant-initials { width: 44px; height: 44px; font-size: 15px; }
+      .tg-answer { padding: 12px 14px; font-size: 15px; grid-template-columns: 28px 1fr; gap: 10px; }
+      .tg-answer-letter { width: 28px; height: 28px; font-size: 10pt; }
+      .tg-rehash-row { grid-template-columns: 24px 1fr auto; padding: 8px 12px; font-size: 14px; }
+      .tg-paper-card { padding: 18px 18px; }
+      @keyframes paper-throw {
+        0%   { transform: scale(0.6) rotate(-12deg); opacity: 0; }
+        70%  { transform: scale(1.04) rotate(2deg); opacity: 1; }
+        100% { transform: scale(1) rotate(0); opacity: 1; }
+      }
+    }
+  </style>
+</Layout>


### PR DESCRIPTION
## Summary

A new game: **Answer the Giants** at `/trivia`. Wordle cadence (3 questions a day, 3 papers a day). Mechanic: pick any answer from four — **all of them are correct**. The Wike Coherence Law says grass, dogs, and people live by the same rules, and every answer is the same answer dressed up differently. The game reveals the unified framing, shows which one you picked, then **throws the relevant paper at you** — an amber-bordered card flying in from off-screen (0.85s cubic-bezier) with paper number, title, tag, plain-English line, abstract, a "why this paper" blurb, and a Read link.

## Files

| File | What it does |
|---|---|
| `src/pages/trivia.astro` | The game page — intro / question / reveal / done screens, PRNG daily rotation, localStorage state, paper-throw animation |
| `src/data/trivia.json` | 20 questions across 20 giants (Heraclitus, Schrödinger, Einstein, Chalmers, Zwicky, Van Gogh, Hawking, DJ Kool Herc, ...) |
| `src/data/papers.json` | 20 papers enriched with `abstract`, `core_claim`, `plain_english`, `status="Speculative"` so the thrown paper shows real content |
| `scripts/enrich-trivia-papers.mjs` | One-off enrichment script, kept in-tree for reproducibility |
| `src/pages/games.astro` | New "Answer the Giants" card prepended to games hub (tag: NEW) |
| `src/layouts/Layout.astro` | `/trivia` added to Apps dropdown (desktop + mobile drawer) |

## Giants covered

Schrödinger (life), Chalmers (consciousness), Zwicky (dark matter), Einstein (vacuum), Oparin (origin of life), Heraclitus (river), Rabi ("who ordered the muon"), Fleming (photosynthesis), Van Gogh (Starry Night turbulence), Hawking (black holes), McCraty (heart sync), Guth (inflation), Smoot (CMB), JWST (early massive galaxies), Lorimer (FRBs), Bednorz/Müller (high-Tc), Bell Burnell (neutron-star kicks), Rayleigh (thermoacoustic), Landau (universality), DJ Kool Herc (hip-hop as coherence transmission).

## Daily rotation

`xmur3 + sfc32` seeded on today's `YYYY-MM-DD`. Everyone playing the same day gets the same three. Mid-round state persists in localStorage (`trivia_today_progress`), collected slugs accumulate in `trivia_collected_slugs`, and the done screen counts down to midnight.

## Review gate on paper metadata

The 20 enriched abstracts are marked `status: "Speculative"` — they render as a yellow badge on each paper page. I drafted them from commit-message context and paper titles; they are plausible but not author-verified. **Spot-check before flipping them to `"Verified"`.** If any misrepresent the physics, edit in place or revert that paper's entry.

## Test plan

- [ ] Visit `/trivia` → intro screen loads with papers/sessions counters.
- [ ] Click Begin → first question renders with giant card + four answers.
- [ ] Click any answer → reveal fires: "Yes. You're correct." / "And so is every other answer." / unified_reveal paragraph / answer re-hash with `← you` marker / watermarked equation / paper card animates in from off-screen.
- [ ] "Next →" advances to question 2, then 3.
- [ ] After 3rd reveal, "Finish →" lands on done screen with today's 3 papers + countdown to midnight.
- [ ] Reload mid-round → resumes on the right question.
- [ ] Reload after finishing → locked done screen with countdown.
- [ ] `/games` hub shows "Answer the Giants 🧠" card; clicks → `/trivia`.
- [ ] Apps dropdown (desktop + mobile) shows `Answer the Giants 🧠`.
- [ ] Click "Read →" on a thrown paper card → `/papers/{slug}` page shows enriched abstract + yellow "Speculative" status badge.
- [ ] Mobile (640px): answers stack, paper-throw animation swaps to scale-in (no horizontal overflow).

Build: 176 pages (was 175 + /trivia), clean.