### PR TITLE
Restrict AskBuddy API browser origins

### DIFF
--- a/functions/api/askbuddy.js
+++ b/functions/api/askbuddy.js
@@ -22,7 +22,8 @@ const BUDDY_SITE_MAX_TOKENS = 128;
 const PRIMARY_ORIGIN = 'https://aiit-threshold.com';
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(www\.)?aiit-threshold\.com$/i,
-  /^https:\/\/[-a-z0-9]+\.pages\.dev$/i,
+  /^https:\/\/[a-f0-9]+\.buddy-bb4\.pages\.dev$/i,
+  /^https:\/\/[-a-z0-9]+\.buddy-bb4\.pages\.dev$/i,
   /^https?:\/\/localhost(?::\d+)?$/i,
   /^https?:\/\/127\.0\.0\.1(?::\d+)?$/i,
   /^capacitor:\/\/localhost$/i,

--- a/functions/api/askbuddy.js
+++ b/functions/api/askbuddy.js
@@ -19,6 +19,15 @@ import { callBuddy } from '../_lib/ingest.js';
 
 const MAX_QUESTION_LEN = 600;
 const BUDDY_SITE_MAX_TOKENS = 128;
+const PRIMARY_ORIGIN = 'https://aiit-threshold.com';
+const ALLOWED_ORIGIN_PATTERNS = [
+  /^https:\/\/(www\.)?aiit-threshold\.com$/i,
+  /^https:\/\/[-a-z0-9]+\.pages\.dev$/i,
+  /^https?:\/\/localhost(?::\d+)?$/i,
+  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/i,
+  /^capacitor:\/\/localhost$/i,
+  /^ionic:\/\/localhost$/i,
+];
 
 // First-output shape helpers (see DEV_ARCHITECTURE.md → Response Shape)
 const OBSERVATIONS = [
@@ -41,17 +50,44 @@ function rollObservation() {
   return null;
 }
 
-function corsHeaders() {
+function isAllowedOrigin(value) {
+  if (!value || value === 'null') return false;
+  return ALLOWED_ORIGIN_PATTERNS.some(re => re.test(value));
+}
+
+function isAllowedReferer(value) {
+  if (!value) return false;
+  try {
+    return isAllowedOrigin(new URL(value).origin);
+  } catch {
+    return false;
+  }
+}
+
+function requestFromAllowedSurface(request) {
+  const origin = request.headers.get('origin') || '';
+  const referer = request.headers.get('referer') || '';
+
+  // Browser traffic must come from an allowed surface. Direct server-side calls
+  // usually have neither header; leave those to IP/KV throttling instead of
+  // breaking health checks or native wrappers.
+  if (!origin && !referer) return true;
+  return isAllowedOrigin(origin) || isAllowedReferer(referer);
+}
+
+function corsHeaders(request) {
+  const origin = request.headers.get('origin') || '';
   return {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : PRIMARY_ORIGIN,
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, X-Dev-Bypass',
+    'Vary': 'Origin',
   };
 }
 
-export async function onRequestOptions() {
-  return new Response(null, { status: 204, headers: corsHeaders() });
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: corsHeaders(request) });
 }
 
 async function sha256Hex(s) {
@@ -65,7 +101,11 @@ function todayKey() {
 }
 export async function onRequestPost(context) {
   const { request, env } = context;
-  const headers = corsHeaders();
+  const headers = corsHeaders(request);
+
+  if (!requestFromAllowedSurface(request)) {
+    return new Response(JSON.stringify({ ok: false, error: 'forbidden_origin' }), { status: 403, headers });
+  }
 
   if (!env.BUDDY_BACKEND_URL || !env.BUDDY_CF_ACCESS_CLIENT_ID || !env.BUDDY_CF_ACCESS_CLIENT_SECRET) {
     return new Response(JSON.stringify({

--- a/functions/api/askbuddy_poll.js
+++ b/functions/api/askbuddy_poll.js
@@ -2,6 +2,16 @@
 
 import { callBuddyPoll } from '../_lib/ingest.js';
 
+const PRIMARY_ORIGIN = 'https://aiit-threshold.com';
+const ALLOWED_ORIGIN_PATTERNS = [
+  /^https:\/\/(www\.)?aiit-threshold\.com$/i,
+  /^https:\/\/[-a-z0-9]+\.pages\.dev$/i,
+  /^https?:\/\/localhost(?::\d+)?$/i,
+  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/i,
+  /^capacitor:\/\/localhost$/i,
+  /^ionic:\/\/localhost$/i,
+];
+
 const OBSERVATIONS = [
   'you moved on that before you fully explained it.',
   'you knew where that was going early.',
@@ -22,22 +32,53 @@ function rollObservation() {
   return null;
 }
 
-function corsHeaders() {
+function isAllowedOrigin(value) {
+  if (!value || value === 'null') return false;
+  return ALLOWED_ORIGIN_PATTERNS.some(re => re.test(value));
+}
+
+function isAllowedReferer(value) {
+  if (!value) return false;
+  try {
+    return isAllowedOrigin(new URL(value).origin);
+  } catch {
+    return false;
+  }
+}
+
+function requestFromAllowedSurface(request) {
+  const origin = request.headers.get('origin') || '';
+  const referer = request.headers.get('referer') || '';
+
+  // Browser traffic must come from an allowed surface. Direct server-side calls
+  // usually have neither header; leave those to IP/KV throttling instead of
+  // breaking health checks or native wrappers.
+  if (!origin && !referer) return true;
+  return isAllowedOrigin(origin) || isAllowedReferer(referer);
+}
+
+function corsHeaders(request) {
+  const origin = request.headers.get('origin') || '';
   return {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : PRIMARY_ORIGIN,
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type, X-Dev-Bypass',
+    'Vary': 'Origin',
   };
 }
 
-export async function onRequestOptions() {
-  return new Response(null, { status: 204, headers: corsHeaders() });
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: corsHeaders(request) });
 }
 
 export async function onRequestPost(context) {
   const { request, env } = context;
-  const headers = corsHeaders();
+  const headers = corsHeaders(request);
+
+  if (!requestFromAllowedSurface(request)) {
+    return new Response(JSON.stringify({ ok: false, error: 'forbidden_origin' }), { status: 403, headers });
+  }
 
   if (!env.BUDDY_BACKEND_URL || !env.BUDDY_CF_ACCESS_CLIENT_ID || !env.BUDDY_CF_ACCESS_CLIENT_SECRET) {
     return new Response(JSON.stringify({

--- a/functions/api/askbuddy_poll.js
+++ b/functions/api/askbuddy_poll.js
@@ -5,7 +5,8 @@ import { callBuddyPoll } from '../_lib/ingest.js';
 const PRIMARY_ORIGIN = 'https://aiit-threshold.com';
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(www\.)?aiit-threshold\.com$/i,
-  /^https:\/\/[-a-z0-9]+\.pages\.dev$/i,
+  /^https:\/\/[a-f0-9]+\.buddy-bb4\.pages\.dev$/i,
+  /^https:\/\/[-a-z0-9]+\.buddy-bb4\.pages\.dev$/i,
   /^https?:\/\/localhost(?::\d+)?$/i,
   /^https?:\/\/127\.0\.0\.1(?::\d+)?$/i,
   /^capacitor:\/\/localhost$/i,


### PR DESCRIPTION
## Summary

Adds explicit origin/referer validation to the public AskBuddy API endpoints.

## Critical fixed

Before this PR:

- `/api/askbuddy` returned `Access-Control-Allow-Origin: *` and did not gate browser origins before sending traffic to the Buddy backend.
- `/api/askbuddy_poll` also returned wildcard CORS and did not gate browser origins.
- `joke.js` already had an origin check, so AskBuddy was the inconsistent high-risk path.

After this PR:

- Browser calls must come from an allowed AIIT surface.
- Allowed surfaces include `aiit-threshold.com`, Cloudflare Pages previews, local dev, and common native-wrapper origins.
- Direct server-side calls with no browser origin/referer are still allowed so health checks/native wrappers are not accidentally broken.
- CORS now reflects allowed origins instead of using `*`.

## Why

AskBuddy is a public GPU-backed endpoint. Leaving it callable from arbitrary browser origins invites abuse, spam traffic, and noisy backend load. This is a critical reliability boundary for the live site.