### PR TITLE
Add site integrity regression guards

### DIFF
--- a/scripts/guard-buddy-routes.mjs
+++ b/scripts/guard-buddy-routes.mjs
@@ -9,6 +9,11 @@ const scannedFiles = [
   'src/pages/ask-buddy.astro',
   'src/pages/index.astro',
 ];
+const apiFiles = [
+  'functions/api/askbuddy.js',
+  'functions/api/askbuddy_poll.js',
+  'functions/api/joke.js',
+];
 
 const forbidden = [
   /api\.anthropic\.com/i,
@@ -20,33 +25,66 @@ const forbidden = [
 
 let failed = false;
 
+function fail(message) {
+  console.error(message);
+  failed = true;
+}
+
+function readProjectFile(file) {
+  return readFileSync(resolve(root, file), 'utf8');
+}
+
 for (const file of scannedFiles) {
   const abs = resolve(root, file);
   const text = readFileSync(abs, 'utf8');
   for (const pattern of forbidden) {
     if (pattern.test(text)) {
-      console.error(`[buddy-route-guard] forbidden pattern ${pattern} in ${relative(root, abs)}`);
-      failed = true;
+      fail(`[buddy-route-guard] forbidden pattern ${pattern} in ${relative(root, abs)}`);
     }
   }
 }
 
-const askbuddy = readFileSync(resolve(root, 'functions/api/askbuddy.js'), 'utf8');
+const askbuddy = readProjectFile('functions/api/askbuddy.js');
 if (!/\bcallBuddy\b/.test(askbuddy) || !/endpoint:\s*['"]\/ask['"]/.test(askbuddy)) {
-  console.error('[buddy-route-guard] askbuddy.js must route through callBuddy(... endpoint: /ask).');
-  failed = true;
+  fail('[buddy-route-guard] askbuddy.js must route through callBuddy(... endpoint: /ask).');
 }
 
-const joke = readFileSync(resolve(root, 'functions/api/joke.js'), 'utf8');
+const joke = readProjectFile('functions/api/joke.js');
 if (!/\bcallBuddy\b/.test(joke) || !/endpoint:\s*['"]\/ask['"]/.test(joke)) {
-  console.error('[buddy-route-guard] joke.js must route through callBuddy(... endpoint: /ask).');
-  failed = true;
+  fail('[buddy-route-guard] joke.js must route through callBuddy(... endpoint: /ask).');
 }
 
-const poll = readFileSync(resolve(root, 'functions/api/askbuddy_poll.js'), 'utf8');
+const poll = readProjectFile('functions/api/askbuddy_poll.js');
 if (!/\bcallBuddyPoll\b/.test(poll)) {
-  console.error('[buddy-route-guard] askbuddy_poll.js must route through callBuddyPoll.');
-  failed = true;
+  fail('[buddy-route-guard] askbuddy_poll.js must route through callBuddyPoll.');
+}
+
+for (const file of apiFiles) {
+  const text = readProjectFile(file);
+  if (/['"]Access-Control-Allow-Origin['"]\s*:\s*['"]\*['"]/.test(text)) {
+    fail(`[site-integrity-guard] wildcard CORS is forbidden in ${file}.`);
+  }
+  if (text.includes('[-a-z0-9]+\\.pages\\.dev') && !text.includes('buddy-bb4\\.pages\\.dev')) {
+    fail(`[site-integrity-guard] broad Cloudflare Pages origin allowlist is forbidden in ${file}; scope it to this project.`);
+  }
+}
+
+for (const file of ['functions/api/askbuddy.js', 'functions/api/askbuddy_poll.js']) {
+  const text = readProjectFile(file);
+  if (!/requestFromAllowedSurface/.test(text)) {
+    fail(`[site-integrity-guard] ${file} must validate browser origin/referer before backend access.`);
+  }
+  if (!/buddy-bb4\\\.pages\\\.dev/.test(text)) {
+    fail(`[site-integrity-guard] ${file} must scope Cloudflare Pages previews to buddy-bb4.pages.dev.`);
+  }
+}
+
+const paperIndex = readProjectFile('scripts/build-paper-index.mjs');
+if (!/CANONICAL_MAX_PAPER\s*=\s*154/.test(paperIndex)) {
+  fail('[site-integrity-guard] build-paper-index.mjs must enforce canonical max paper number 154.');
+}
+if (/nextNum\s*=\s*maxNum\s*\+\s*1/.test(paperIndex) || /p\.num\s*=\s*newNumStr/.test(paperIndex)) {
+  fail('[site-integrity-guard] build-paper-index.mjs must not invent new public paper numbers for collisions.');
 }
 
 if (failed) {
@@ -54,3 +92,4 @@ if (failed) {
 }
 
 console.log('[buddy-route-guard] Buddy routes are Cloudflare Buddy-only.');
+console.log('[site-integrity-guard] Public API and paper-number integrity checks passed.');


### PR DESCRIPTION
Superseded by a cleaner v2 approach that adds a separate `guard-site-integrity.mjs` file instead of rewriting the existing route guard. Closing this PR to keep review noise down.