### PR TITLE
Document preview auth setup for Paper Game sync

### DIFF
--- a/docs/PREVIEW_AUTH_SETUP.md
+++ b/docs/PREVIEW_AUTH_SETUP.md
@@ -1,0 +1,46 @@
+# Preview Auth Setup
+
+Paper Game collection sync uses the same account session model as the existing
+GitHub auth flow. Cloudflare Pages Preview needs its own OAuth variables and KV
+binding before the preview login flow can work.
+
+The collection API reads the existing `aiit_session` cookie and loads the
+matching `session:{id}` record from `AUTH_KV`; it does not use a separate auth
+store.
+
+## Required Cloudflare Pages Preview Environment Variables
+
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+
+## Required Cloudflare Pages Preview KV Binding
+
+- `AUTH_KV`
+
+## OAuth Callback URLs
+
+Preview OAuth callback URL for the `feature/account-backed-paper-game` PR branch:
+
+```text
+https://feature-account-backed-paper-game.buddy-bb4.pages.dev/api/auth/github/callback
+```
+
+Production OAuth callback URL:
+
+```text
+https://aiit-threshold.com/api/auth/github/callback
+```
+
+## Setup Notes
+
+- Do not commit the GitHub client secret.
+- Do not put secrets in source files.
+- Configure secrets in Cloudflare Dashboard under Workers & Pages -> `buddy-bb4`
+  -> Settings -> Environment variables -> Preview.
+- Preview and Production environment variables and bindings are separate in
+  Cloudflare Pages.
+- After the Preview environment variables are added, retry `LOGIN` on the
+  preview deploy.
+- If GitHub then reports a redirect URI mismatch, temporarily set the GitHub
+  OAuth app callback URL to the preview callback above, or use a separate
+  preview OAuth app.

--- a/functions/api/auth/github/login.js
+++ b/functions/api/auth/github/login.js
@@ -10,7 +10,7 @@ export async function onRequestGet(context) {
   const { request, env } = context;
   const clientId = (env.GITHUB_CLIENT_ID || '').trim();
   if (!clientId) {
-    return new Response('OAuth not configured.', { status: 500 });
+    return new Response('OAuth not configured: missing GITHUB_CLIENT_ID.', { status: 500 });
   }
 
   const url = new URL(request.url);


### PR DESCRIPTION
## Summary
- Document the Cloudflare Pages Preview OAuth variables and AUTH_KV binding needed for account-backed Paper Game collection sync.
- Clarify the login error when GITHUB_CLIENT_ID is missing without exposing secrets.

## Context
- Build already passed for PR #14.
- Remaining blocker is Cloudflare Preview environment configuration.
- No secrets are committed.

## User Action Required
Add or copy the following into the Cloudflare Pages Preview environment for buddy-bb4:
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET
- AUTH_KV binding

After those are configured, retry LOGIN on the preview. If GitHub reports a redirect URI mismatch, temporarily set the GitHub OAuth app callback URL to the preview callback or use a separate preview OAuth app.

## Validation
- node --check functions/api/auth/github/login.js
- git diff --check