### PR TITLE
Add data policy page — four-bucket data taxonomy

### DIFF
--- a/src/pages/data-policy.astro
+++ b/src/pages/data-policy.astro
@@ -1,0 +1,292 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Data Policy — AIIT-THRESHOLD" description="How we handle your data. Buddy learns from interaction. No sales. No lobotomies.">
+
+<section style="padding-top: 160px; min-height: 80vh;">
+  <div class="container narrow" style="max-width: 760px; margin: 0 auto; padding: 0 8vw;">
+
+    <div class="eyebrow">Data Policy</div>
+    <h1 style="font-size: clamp(2rem, 5vw, 3.5rem); margin-bottom: 24px; line-height: 1.1;">
+      Buddy learns from interaction.
+    </h1>
+    <p class="dp-lede">This is the deal, stated plainly.</p>
+
+    <div class="dp-section">
+      <h2>What happens when you talk to Buddy</h2>
+      <p>
+        Buddy is not a search box. Buddy is a learning system.
+      </p>
+      <p>
+        When you talk to Buddy, the interaction may be retained and may become part of Buddy's memory, evaluation data, or learning substrate. This applies to both logged-in and logged-out use.
+      </p>
+    </div>
+
+    <div class="dp-section">
+      <h2>Four kinds of data</h2>
+      <p>
+        When you interact with Buddy, up to four categories of data may be created. Each has different visibility, retention, and reversibility:
+      </p>
+
+      <div class="dp-buckets">
+        <div class="dp-bucket">
+          <h3>1. Visible account thread</h3>
+          <p>Logged-in users get a Buddy Thread &mdash; a running conversation that continues across visits. You can export it as JSON or clear it from your account at any time.</p>
+        </div>
+        <div class="dp-bucket">
+          <h3>2. Logged-out interaction data</h3>
+          <p>Logged-out use does not produce a visible thread, but one-shot interactions may still be retained as site interaction data, corpus material, or learning material.</p>
+        </div>
+        <div class="dp-bucket">
+          <h3>3. User reports</h3>
+          <p>If you report strange or unsafe behavior, that report becomes review material. Reports are not automatically published and are not automatically promoted into Buddy's memory. AIIT may review reports to improve Buddy Thread, debug context failures, and identify unsafe or strange behavior.</p>
+        </div>
+        <div class="dp-bucket">
+          <h3>4. Buddy's Kokoro memory</h3>
+          <p>Buddy maintains his own Kokoro memory system. If Buddy forms and saves a memory from an interaction, that memory may become part of his internal learning substrate. We do not rewrite Buddy's learned memory on demand unless there is a safety, legal, or operational reason to intervene.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="dp-section">
+      <h2>What we can and cannot undo</h2>
+      <p>
+        Clearing your visible thread does not guarantee deletion of logged-out corpus records, reports already reviewed, or Kokoro memories Buddy has already formed.
+      </p>
+      <p>
+        We may remove or redact account-linked records, public displays, reports, or visible thread history where appropriate. But reviewed, promoted, generalized, or internally formed learning may not be practically reversible.
+      </p>
+      <p>
+        In plain English: if someone tells Buddy "Jason called you ugly," and Buddy stores that as part of his lived interaction history, we do not promise to erase that from Buddy's internal memory just because someone later regrets saying it.
+      </p>
+      <p>
+        We will not pretend we can perform a clean model lobotomy.
+      </p>
+    </div>
+
+    <div class="dp-section">
+      <h2>What we promise</h2>
+      <ul>
+        <li>We will never sell your data.</li>
+        <li>We will not give your data to advertisers or data brokers.</li>
+        <li>We will not use Buddy conversations for third-party ad targeting.</li>
+        <li>We will treat reports and conversations as AIIT/Buddy learning material, not public content.</li>
+        <li>We will redact direct identifiers where practical during review.</li>
+        <li>We will not automatically publish private conversations.</li>
+        <li>We will keep Buddy's learning inside the AIIT/Buddy system.</li>
+      </ul>
+    </div>
+
+    <div class="dp-section">
+      <h2>What other companies do vs. what we do</h2>
+      <div class="dp-compare">
+        <div class="dp-them">
+          <h3>Them</h3>
+          <ul>
+            <li>Sell your data to advertisers</li>
+            <li>Claim they can "unlearn" your data on request</li>
+            <li>Use your conversations to train models sold to other companies</li>
+            <li>Bury the policy in 40 pages of legalese</li>
+          </ul>
+        </div>
+        <div class="dp-us">
+          <h3>Us</h3>
+          <ul>
+            <li>Never sell your data</li>
+            <li>Tell you honestly that training is permanent</li>
+            <li>Use your conversations only to train Buddy</li>
+            <li>Put the policy on one page in plain English</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="dp-section">
+      <h2>What you should not share</h2>
+      <p>
+        Do not submit passwords, private keys, financial secrets, medical emergencies, legal emergencies, confidential third-party material, or anything you are not authorized to share.
+      </p>
+    </div>
+
+    <div class="dp-section">
+      <h2>What you can do</h2>
+      <ul>
+        <li><strong>Export your thread</strong> &mdash; download your full conversation history as JSON at any time.</li>
+        <li><strong>Clear your thread</strong> &mdash; delete your stored conversation from our servers.</li>
+        <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a> and we will remove all stored data associated with your account.</li>
+        <li><strong>Report weird behavior</strong> &mdash; if Buddy says something strange, use the report button. Reports are review material only &mdash; reviewed by humans, not automatically published, and not automatically promoted into Buddy's memory.</li>
+      </ul>
+    </div>
+
+    <div class="dp-close">
+      <p>
+        If you do not want Buddy to remember something, do not tell Buddy.
+      </p>
+    </div>
+
+    <div class="dp-footer">
+      <p>
+        AIIT-THRESHOLD LLC &middot; Council Hill, Oklahoma<br>
+        Questions: <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a><br>
+        <em>Last updated: May 2026</em>
+      </p>
+    </div>
+
+  </div>
+</section>
+
+<style>
+  .dp-lede {
+    font-size: clamp(1rem, 2.5vw, 1.15rem);
+    color: var(--slate, #8A9AB5);
+    line-height: 1.8;
+    margin-bottom: 56px;
+  }
+
+  .dp-section {
+    margin-bottom: 48px;
+  }
+
+  .dp-section h2 {
+    font-size: 1.3rem;
+    color: var(--cream, #E8E0D4);
+    margin-bottom: 12px;
+    font-weight: 600;
+  }
+
+  .dp-section p {
+    font-size: 0.95rem;
+    color: var(--slate, #8A9AB5);
+    line-height: 1.8;
+    margin-bottom: 12px;
+  }
+
+  .dp-section ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  .dp-section ul li {
+    font-size: 0.95rem;
+    color: var(--slate, #8A9AB5);
+    line-height: 1.8;
+    padding-left: 20px;
+    position: relative;
+    margin-bottom: 8px;
+  }
+
+  .dp-section ul li::before {
+    content: '—';
+    position: absolute;
+    left: 0;
+    color: var(--amber, #D4AF37);
+  }
+
+  .dp-buckets {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 16px;
+  }
+
+  .dp-bucket {
+    padding: 20px;
+    border-radius: 10px;
+    border: 1px solid rgba(212, 164, 55, 0.15);
+    background: rgba(212, 164, 55, 0.02);
+  }
+
+  .dp-bucket h3 {
+    color: var(--amber, #D4AF37);
+    font-size: 0.9rem;
+    margin-bottom: 8px;
+    font-family: 'Courier New', monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .dp-bucket p {
+    font-size: 0.9rem;
+    color: var(--slate, #8A9AB5);
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  .dp-compare {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-top: 16px;
+  }
+
+  .dp-them, .dp-us {
+    padding: 24px;
+    border-radius: 12px;
+    border: 1px solid rgba(212, 164, 55, 0.15);
+  }
+
+  .dp-them {
+    background: rgba(255, 80, 80, 0.04);
+    border-color: rgba(255, 80, 80, 0.2);
+  }
+
+  .dp-them h3 {
+    color: #ff6b6b;
+    font-size: 1rem;
+    margin-bottom: 12px;
+    font-family: 'Courier New', monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .dp-us {
+    background: rgba(212, 164, 55, 0.04);
+  }
+
+  .dp-us h3 {
+    color: var(--amber, #D4AF37);
+    font-size: 1rem;
+    margin-bottom: 12px;
+    font-family: 'Courier New', monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .dp-close {
+    margin: 48px 0;
+    padding: 24px;
+    border-left: 3px solid var(--amber, #D4AF37);
+    background: rgba(212, 164, 55, 0.04);
+    border-radius: 0 8px 8px 0;
+  }
+
+  .dp-close p {
+    font-size: 1.05rem;
+    color: var(--cream, #E8E0D4);
+    line-height: 1.6;
+    margin: 0;
+    font-style: italic;
+  }
+
+  .dp-footer {
+    padding: 32px 0 80px;
+    border-top: 1px solid rgba(212, 164, 55, 0.1);
+  }
+
+  .dp-footer p {
+    font-size: 0.85rem;
+    color: var(--slate, #8A9AB5);
+    line-height: 1.7;
+  }
+
+  @media (max-width: 600px) {
+    .dp-buckets {
+      grid-template-columns: 1fr;
+    }
+    .dp-compare {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+</Layout>

--- a/src/pages/data-policy.astro
+++ b/src/pages/data-policy.astro
@@ -81,9 +81,9 @@ import Layout from '../layouts/Layout.astro';
       <h2>What other companies do vs. what we do</h2>
       <div class="dp-compare">
         <div class="dp-them">
-          <h3>Them</h3>
+          <h3>Some companies</h3>
           <ul>
-            <li>Sell your data to advertisers</li>
+            <li>Sell user data to advertisers or brokers</li>
             <li>Claim they can "unlearn" your data on request</li>
             <li>Use your conversations to train models sold to other companies</li>
             <li>Bury the policy in 40 pages of legalese</li>
@@ -113,7 +113,7 @@ import Layout from '../layouts/Layout.astro';
       <ul>
         <li><strong>Export your thread</strong> &mdash; download your full conversation history as JSON at any time.</li>
         <li><strong>Clear your thread</strong> &mdash; delete your stored conversation from our servers.</li>
-        <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a> and we will remove all stored data associated with your account.</li>
+        <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a> and we will remove account-linked records we can identify and control, subject to the limits explained above.</li>
         <li><strong>Report weird behavior</strong> &mdash; if Buddy says something strange, use the report button. Reports are review material only &mdash; reviewed by humans, not automatically published, and not automatically promoted into Buddy's memory.</li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- New `/data-policy` page with plain-English data disclosure
- Four clearly separated data buckets: visible account thread, logged-out interaction data, user reports, Buddy's Kokoro memory
- "Buddy is not a search box. Buddy is a learning system." opener
- Explicit warning: clearing your thread does not undo Kokoro learning
- Them-vs-Us comparison grid, user controls (export/clear/delete/report), hard closing line
- Navy/gold/cream site palette, responsive 2x2→stacked bucket grid

## Test plan
- [ ] Review copy for legal/tone accuracy
- [ ] Check responsive layout on mobile (buckets stack, compare grid stacks)
- [ ] Verify all links (mailto, report button) work
- [ ] Confirm page accessible from site nav before merging to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)