### PR TITLE
Buddy Thread: early-access notice + report modal + endpoint

### DIFF
--- a/docs/SNAPPY_NAV_STANDARD.md
+++ b/docs/SNAPPY_NAV_STANDARD.md
@@ -1,0 +1,56 @@
+# Snappy Navigation Standard
+
+Status: active site standard
+Date: 2026-05-20
+
+AIIT_SITE uses a McMaster-style navigation performance layer: static HTML stays real, likely pages are warmed before click, and repeat navigations are served from the browser/service-worker cache.
+
+## Required Pieces
+
+- `src/layouts/Layout.astro` must preload and load `/snappy-nav.js` on every normal page.
+- `public/snappy-nav.js` owns intent prefetch:
+  - idle prefetch for high-traffic routes
+  - hover prefetch
+  - focus prefetch
+  - touchstart prefetch
+  - mousedown prefetch
+  - service-worker registration
+- `public/sw.js` owns runtime caching:
+  - static core assets
+  - stale-while-revalidate HTML page cache
+  - cache-first runtime assets
+  - API, download, and large media exclusions
+- `public/_headers` owns Cloudflare Pages cache behavior:
+  - CDN stale-while-revalidate for static HTML
+  - no-store for `/sw.js`
+  - immutable caching for hashed Astro assets
+  - bounded cache for images and runtime scripts
+
+## Rules For Future Pages
+
+- Use the shared layout unless there is a strong reason not to.
+- Same-origin page links should be normal `<a href="/route">` anchors so `snappy-nav.js` can warm them.
+- Do not attach prefetch to API routes, downloads, external links, or large media.
+- Add `data-no-prefetch="true"` to any same-origin link that must never be warmed.
+- Keep the visible nav loader delayed; fast navigations should not flash a loading overlay.
+- Bump the version in `snappy-nav.js` and `sw.js` when changing cache behavior.
+
+## Verification
+
+Before shipping changes to this layer:
+
+```bash
+npm run build
+```
+
+Then verify in a browser:
+
+- service worker controls the page after one reload
+- hovering a visible same-origin link places that page in `aiit-pages-*`
+- clicking the warmed link renders the destination without loader flash
+- no relevant console errors beyond local-preview-only missing Cloudflare Functions
+
+Known local preview-only 404s:
+
+- `/api/auth/me`
+- `/api/paper-game/collection`

--- a/docs/SNAPPY_NAV_STANDARD.md
+++ b/docs/SNAPPY_NAV_STANDARD.md
@@ -32,6 +32,7 @@ AIIT_SITE uses a McMaster-style navigation performance layer: static HTML stays 
 - Same-origin page links should be normal `<a href="/route">` anchors so `snappy-nav.js` can warm them.
 - Do not attach prefetch to API routes, downloads, external links, or large media.
 - Add `data-no-prefetch="true"` to any same-origin link that must never be warmed.
+- Extensionless same-origin page URLs must canonicalize to the trailing-slash page before service-worker caching. Do not cache or return raw redirect responses for document navigations.
 - Keep the visible nav loader delayed; fast navigations should not flash a loading overlay.
 - Bump the version in `snappy-nav.js` and `sw.js` when changing cache behavior.
 

--- a/functions/_lib/buddyThread.js
+++ b/functions/_lib/buddyThread.js
@@ -122,7 +122,7 @@ export async function appendBuddyThreadTurn(env, user, { question, answer, reque
   const now = new Date().toISOString();
   const record = await loadBuddyThread(env, user, threadId);
 
-  if (requestId && record.messages.some(m => m.role === 'buddy' && m.request_id === requestId)) {
+  if (requestId && record.messages.some(m => m.request_id === requestId)) {
     return record;
   }
 

--- a/functions/_lib/buddyThread.js
+++ b/functions/_lib/buddyThread.js
@@ -1,0 +1,161 @@
+const MAX_THREAD_MESSAGES = 80;
+const MAX_MESSAGE_LEN = 3000;
+const MAX_RECORD_BYTES = 120_000;
+const TEXT_ENCODER = new TextEncoder();
+
+export function parseSessionFromCookie(cookieHeader) {
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(';').map(s => s.trim());
+  for (const part of parts) {
+    if (part.startsWith('aiit_session=')) return part.slice('aiit_session='.length);
+  }
+  return null;
+}
+
+export async function getLoggedInUser(request, env) {
+  if (!env || !env.AUTH_KV) return null;
+  const session = parseSessionFromCookie(request.headers.get('cookie'));
+  if (!session) return null;
+  const raw = await env.AUTH_KV.get(`session:${session}`);
+  if (!raw) return null;
+  try {
+    const user = JSON.parse(raw);
+    return user && (user.login || user.id) ? user : null;
+  } catch {
+    return null;
+  }
+}
+
+export function cleanLogin(user) {
+  return String((user && (user.login || user.id)) || 'unknown')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '_')
+    .slice(0, 80);
+}
+
+export function buddyThreadKey(user, threadId = 'primary') {
+  const cleanThread = String(threadId || 'primary').replace(/[^a-z0-9_-]/gi, '_').slice(0, 50) || 'primary';
+  return `buddy-thread:${cleanLogin(user)}:${cleanThread}`;
+}
+
+export function buddyThreadSessionId(user, threadId = 'primary') {
+  const cleanThread = String(threadId || 'primary').replace(/[^a-z0-9_-]/gi, '_').slice(0, 50) || 'primary';
+  return `buddy-thread:${cleanLogin(user)}:${cleanThread}:v1`;
+}
+
+export async function getBuddyThreadSessionId(env, user, threadId = 'primary') {
+  const record = await loadBuddyThread(env, user, threadId);
+  const cleanThread = String(threadId || 'primary').replace(/[^a-z0-9_-]/gi, '_').slice(0, 50) || 'primary';
+  const epoch = String(record.session_epoch || 'v1').replace(/[^a-z0-9_-]/gi, '_').slice(0, 50) || 'v1';
+  return `buddy-thread:${cleanLogin(user)}:${cleanThread}:${epoch}`;
+}
+
+function emptyRecord(user, threadId = 'primary', now = new Date().toISOString()) {
+  return {
+    login: user && user.login || null,
+    user_id: user && user.id || null,
+    thread_id: threadId,
+    first_seen: now,
+    last_seen: now,
+    messages: [],
+    turn_count: 0,
+    cleared_at: null,
+    session_epoch: 'v1',
+  };
+}
+
+function normalizeMessage(message) {
+  const role = message && message.role === 'buddy' ? 'buddy' : 'user';
+  const text = String((message && message.text) || '').trim().slice(0, MAX_MESSAGE_LEN);
+  if (!text) return null;
+  return {
+    role,
+    text,
+    at: String((message && message.at) || new Date().toISOString()).slice(0, 40),
+    request_id: message && message.request_id ? String(message.request_id).slice(0, 100) : null,
+  };
+}
+
+function trimRecord(record) {
+  if (!Array.isArray(record.messages)) record.messages = [];
+  if (record.messages.length > MAX_THREAD_MESSAGES) {
+    record.messages = record.messages.slice(-MAX_THREAD_MESSAGES);
+  }
+
+  let blob = JSON.stringify(record);
+  while (TEXT_ENCODER.encode(blob).length > MAX_RECORD_BYTES && record.messages.length > 8) {
+    record.messages.shift();
+    blob = JSON.stringify(record);
+  }
+  return record;
+}
+
+export async function loadBuddyThread(env, user, threadId = 'primary') {
+  if (!env || !env.AUTH_KV || !user) return emptyRecord(user, threadId);
+  const raw = await env.AUTH_KV.get(buddyThreadKey(user, threadId));
+  if (!raw) return emptyRecord(user, threadId);
+  try {
+    const record = JSON.parse(raw);
+    return {
+      ...emptyRecord(user, threadId, record.first_seen || undefined),
+      ...record,
+      login: record.login || user.login || null,
+      user_id: record.user_id || user.id || null,
+      thread_id: record.thread_id || threadId,
+      messages: Array.isArray(record.messages) ? record.messages.map(normalizeMessage).filter(Boolean) : [],
+      turn_count: Number(record.turn_count || 0),
+      session_epoch: String(record.session_epoch || 'v1').slice(0, 50),
+    };
+  } catch {
+    return emptyRecord(user, threadId);
+  }
+}
+
+export async function saveBuddyThread(env, user, record, threadId = 'primary') {
+  const next = trimRecord(record);
+  await env.AUTH_KV.put(buddyThreadKey(user, threadId), JSON.stringify(next));
+  return next;
+}
+
+export async function appendBuddyThreadTurn(env, user, { question, answer, requestId, threadId = 'primary' }) {
+  if (!env || !env.AUTH_KV || !user) return null;
+  const now = new Date().toISOString();
+  const record = await loadBuddyThread(env, user, threadId);
+
+  if (requestId && record.messages.some(m => m.role === 'buddy' && m.request_id === requestId)) {
+    return record;
+  }
+
+  const userMessage = normalizeMessage({ role: 'user', text: question, at: now, request_id: requestId });
+  const buddyMessage = normalizeMessage({ role: 'buddy', text: answer, at: now, request_id: requestId });
+  if (userMessage) record.messages.push(userMessage);
+  if (buddyMessage) record.messages.push(buddyMessage);
+  record.last_seen = now;
+  record.turn_count = Number(record.turn_count || 0) + (userMessage && buddyMessage ? 1 : 0);
+  record.cleared_at = null;
+
+  return saveBuddyThread(env, user, record, threadId);
+}
+
+export async function clearBuddyThread(env, user, threadId = 'primary') {
+  const now = new Date().toISOString();
+  const record = emptyRecord(user, threadId, now);
+  record.cleared_at = now;
+  record.session_epoch = Date.now().toString(36);
+  await env.AUTH_KV.put(buddyThreadKey(user, threadId), JSON.stringify(record));
+  return record;
+}
+
+export function publicBuddyThread(record) {
+  return {
+    thread_id: record.thread_id || 'primary',
+    login: record.login || null,
+    first_seen: record.first_seen || null,
+    last_seen: record.last_seen || null,
+    cleared_at: record.cleared_at || null,
+    turn_count: Number(record.turn_count || 0),
+    message_count: Array.isArray(record.messages) ? record.messages.length : 0,
+    messages: Array.isArray(record.messages) ? record.messages : [],
+    session_epoch: record.session_epoch || 'v1',
+  };
+}

--- a/functions/api/askbuddy.js
+++ b/functions/api/askbuddy.js
@@ -16,6 +16,7 @@
 //     → { ok:false, error:"corpus_write_failed" }
 
 import { callBuddy } from '../_lib/ingest.js';
+import { appendBuddyThreadTurn, getBuddyThreadSessionId, getLoggedInUser } from '../_lib/buddyThread.js';
 
 const MAX_QUESTION_LEN = 600;
 const BUDDY_SITE_MAX_TOKENS = 128;
@@ -123,7 +124,7 @@ export async function onRequestPost(context) {
 
   const question = String(body.question || '').trim().slice(0, MAX_QUESTION_LEN);
   const fingerprint = String(body.fingerprint || '').trim().slice(0, 128) || 'nofp';
-  const sessionId = String(body.session_id || '').trim().slice(0, 128) || fingerprint;
+  const browserSessionId = String(body.session_id || '').trim().slice(0, 128) || fingerprint;
   const rawHistory = Array.isArray(body.history) ? body.history : [];
   const history = rawHistory.slice(-6).map(t => ({
     q: String(t && t.q || '').slice(0, MAX_QUESTION_LEN),
@@ -134,6 +135,10 @@ export async function onRequestPost(context) {
   if (!question) {
     return new Response(JSON.stringify({ ok: false, error: 'empty question' }), { status: 400, headers });
   }
+
+  const loggedInUser = await getLoggedInUser(request, env);
+  const accountThread = !!(loggedInUser && (loggedInUser.login || loggedInUser.id));
+  const sessionId = accountThread ? await getBuddyThreadSessionId(env, loggedInUser, 'primary') : browserSessionId;
 
   const ip = request.headers.get('CF-Connecting-IP') ||
              request.headers.get('x-forwarded-for') || 'unknown';
@@ -164,7 +169,15 @@ export async function onRequestPost(context) {
     surface: 'ask',
     userInput: question,
     sessionId,
-    extras: { question, history, max_tokens: BUDDY_SITE_MAX_TOKENS, temperature: 0.25 },
+    extras: {
+      question,
+      history,
+      max_tokens: BUDDY_SITE_MAX_TOKENS,
+      temperature: 0.25,
+      account_thread: accountThread,
+      thread_id: 'primary',
+      user: accountThread ? { login: loggedInUser.login || null, id: loggedInUser.id || null } : null,
+    },
   });
 
   if (!ingest.ok) {
@@ -193,9 +206,11 @@ export async function onRequestPost(context) {
       ok: true,
       status: 'pending',
       request_id: ingest.request_id,
+      session_id: sessionId,
       message: 'buddy got your question, hang tight.',
       cta: 'pass it on',
       layer: 'surface',
+      thread: { enabled: accountThread, saved: false },
     }), { status: 200, headers });
   }
 
@@ -222,12 +237,25 @@ export async function onRequestPost(context) {
   // First-output shape: answer + optional observation + cta + layer.
   // Keeps `ok` and `answer` for back-compat with the current ask-buddy frontend.
   const obs = rollObservation();
+  let threadSaved = false;
+  if (accountThread) {
+    try {
+      await appendBuddyThreadTurn(env, loggedInUser, {
+        question,
+        answer,
+        requestId: ingest.request_id,
+        threadId: 'primary',
+      });
+      threadSaved = true;
+    } catch {}
+  }
   const payload = {
     ok: true,
     answer,
     cta: 'pass it on',
     layer: 'surface',
     remainingToday: 0,
+    thread: { enabled: accountThread, saved: threadSaved },
   };
   if (obs) {
     payload.observation = obs.text;

--- a/functions/api/askbuddy_poll.js
+++ b/functions/api/askbuddy_poll.js
@@ -1,6 +1,7 @@
 // Cloudflare Pages Function: poll a queued AskBuddy answer.
 
 import { callBuddyPoll } from '../_lib/ingest.js';
+import { appendBuddyThreadTurn, getBuddyThreadSessionId, getLoggedInUser } from '../_lib/buddyThread.js';
 
 const PRIMARY_ORIGIN = 'https://aiit-threshold.com';
 const ALLOWED_ORIGIN_PATTERNS = [
@@ -93,10 +94,16 @@ export async function onRequestPost(context) {
   catch { return new Response(JSON.stringify({ ok: false, error: 'invalid json' }), { status: 400, headers }); }
 
   const requestId = String(body.request_id || body.requestId || '').trim();
-  const sessionId = String(body.session_id || body.sessionId || '').trim();
+  const incomingSessionId = String(body.session_id || body.sessionId || '').trim();
+  const question = String(body.question || '').trim().slice(0, 600);
+  const wantsAccountThread = body.account_thread === true;
   if (!requestId) {
     return new Response(JSON.stringify({ ok: false, error: 'missing_request_id' }), { status: 400, headers });
   }
+
+  const loggedInUser = await getLoggedInUser(request, env);
+  const accountThread = wantsAccountThread && !!(loggedInUser && (loggedInUser.login || loggedInUser.id));
+  const sessionId = accountThread ? await getBuddyThreadSessionId(env, loggedInUser, 'primary') : incomingSessionId;
 
   const ingest = await callBuddyPoll({ env, requestId, sessionId });
   if (!ingest.ok) {
@@ -120,6 +127,18 @@ export async function onRequestPost(context) {
   const answer = String(ingest.data.answer || '').trim();
   if (ingest.data.status === 'ready' && answer) {
     const obs = rollObservation();
+    let threadSaved = false;
+    if (accountThread && question) {
+      try {
+        await appendBuddyThreadTurn(env, loggedInUser, {
+          question,
+          answer,
+          requestId: ingest.request_id,
+          threadId: 'primary',
+        });
+        threadSaved = true;
+      } catch {}
+    }
     const payload = {
       ok: true,
       status: 'ready',
@@ -127,6 +146,7 @@ export async function onRequestPost(context) {
       answer,
       cta: 'pass it on',
       layer: 'surface',
+      thread: { enabled: accountThread, saved: threadSaved },
     };
     if (obs) {
       payload.observation = obs.text;

--- a/functions/api/buddy-thread/report.js
+++ b/functions/api/buddy-thread/report.js
@@ -25,18 +25,24 @@ const MAX_NOTE_LEN = 2000;
 const MAX_RECENT_MESSAGES = 10;
 const MAX_MESSAGE_LEN = 1000;
 
-function corsHeaders() {
+function responseHeaders(request) {
+  const origin = request?.headers?.get('origin') || '';
+  const allowed = /^https:\/\/(www\.)?aiit-threshold\.com$/i.test(origin)
+    || /^https:\/\/[-a-z0-9]+\.buddy-bb4\.pages\.dev$/i.test(origin)
+    || /^https?:\/\/localhost(:\d+)?$/i.test(origin);
   return {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Credentials': 'true',
+    ...(allowed ? {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Credentials': 'true',
+    } : {}),
   };
 }
 
-export async function onRequestOptions() {
-  return new Response(null, { status: 204, headers: corsHeaders() });
+export async function onRequestOptions(context) {
+  return new Response(null, { status: 204, headers: responseHeaders(context.request) });
 }
 
 function parseSessionFromCookie(cookieHeader) {
@@ -69,7 +75,7 @@ function randomId() {
 
 export async function onRequestPost(context) {
   const { request, env } = context;
-  const h = corsHeaders();
+  const h = responseHeaders(request);
 
   const user = await getLoggedInUser(request, env);
   if (!user) {

--- a/functions/api/buddy-thread/report.js
+++ b/functions/api/buddy-thread/report.js
@@ -11,6 +11,8 @@
 //     Body: { note, categories, include_recent, recent_messages, thread_id, url }
 //     → { ok: true }
 
+import { getLoggedInUser } from '../../_lib/buddyThread.js';
+
 const ALLOWED_CATEGORIES = [
   'forgot_context',
   'wrong_memory',
@@ -45,27 +47,6 @@ export async function onRequestOptions(context) {
   return new Response(null, { status: 204, headers: responseHeaders(context.request) });
 }
 
-function parseSessionFromCookie(cookieHeader) {
-  if (!cookieHeader) return null;
-  const parts = cookieHeader.split(';').map(s => s.trim());
-  for (const p of parts) {
-    if (p.startsWith('aiit_session=')) return p.slice('aiit_session='.length);
-  }
-  return null;
-}
-
-async function getLoggedInUser(request, env) {
-  const session = parseSessionFromCookie(request.headers.get('cookie'));
-  if (!session || !env.AUTH_KV) return null;
-  const raw = await env.AUTH_KV.get(`session:${session}`);
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
-}
-
 function randomId() {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
   let out = '';
@@ -77,13 +58,13 @@ export async function onRequestPost(context) {
   const { request, env } = context;
   const h = responseHeaders(request);
 
+  if (!env.AUTH_KV) {
+    return new Response(JSON.stringify({ ok: false, error: 'kv_not_bound' }), { status: 500, headers: h });
+  }
+
   const user = await getLoggedInUser(request, env);
   if (!user) {
     return new Response(JSON.stringify({ ok: false, error: 'login_required' }), { status: 401, headers: h });
-  }
-
-  if (!env.AUTH_KV) {
-    return new Response(JSON.stringify({ ok: false, error: 'kv_not_bound' }), { status: 500, headers: h });
   }
 
   let body;

--- a/functions/api/buddy-thread/report.js
+++ b/functions/api/buddy-thread/report.js
@@ -112,9 +112,13 @@ export async function onRequestPost(context) {
     created_at: now,
   };
 
-  await env.AUTH_KV.put(kvKey, JSON.stringify(report), {
-    expirationTtl: 60 * 60 * 24 * 365,
-  });
+  try {
+    await env.AUTH_KV.put(kvKey, JSON.stringify(report), {
+      expirationTtl: 60 * 60 * 24 * 365,
+    });
+  } catch {
+    return new Response(JSON.stringify({ ok: false, error: 'report_write_failed' }), { status: 500, headers: h });
+  }
 
-  return new Response(JSON.stringify({ ok: true }), { status: 200, headers: h });
+  return new Response(JSON.stringify({ ok: true, report_id: rid, created_at: now }), { status: 200, headers: h });
 }

--- a/functions/api/buddy-thread/report.js
+++ b/functions/api/buddy-thread/report.js
@@ -1,0 +1,133 @@
+// Cloudflare Pages Function: Buddy Thread report endpoint.
+// Stores user-submitted reports in AUTH_KV. Reports are review material only —
+// not auto-published, not auto-promoted into Buddy's memory, not used as
+// training data unless manually promoted later.
+//
+// KV binding required: AUTH_KV (same namespace as auth system)
+//
+// Endpoint:
+//   POST /api/buddy-thread/report
+//     Requires login (aiit_session cookie).
+//     Body: { note, categories, include_recent, recent_messages, thread_id, url }
+//     → { ok: true }
+
+const ALLOWED_CATEGORIES = [
+  'forgot_context',
+  'wrong_memory',
+  'overconnected',
+  'strange_answer',
+  'stuck_loop',
+  'unsafe',
+  'other',
+];
+
+const MAX_NOTE_LEN = 2000;
+const MAX_RECENT_MESSAGES = 10;
+const MAX_MESSAGE_LEN = 1000;
+
+function corsHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
+  };
+}
+
+export async function onRequestOptions() {
+  return new Response(null, { status: 204, headers: corsHeaders() });
+}
+
+function parseSessionFromCookie(cookieHeader) {
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(';').map(s => s.trim());
+  for (const p of parts) {
+    if (p.startsWith('aiit_session=')) return p.slice('aiit_session='.length);
+  }
+  return null;
+}
+
+async function getLoggedInUser(request, env) {
+  const session = parseSessionFromCookie(request.headers.get('cookie'));
+  if (!session || !env.AUTH_KV) return null;
+  const raw = await env.AUTH_KV.get(`session:${session}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function randomId() {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let out = '';
+  for (let i = 0; i < 8; i++) out += chars[Math.floor(Math.random() * chars.length)];
+  return out;
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const h = corsHeaders();
+
+  const user = await getLoggedInUser(request, env);
+  if (!user) {
+    return new Response(JSON.stringify({ ok: false, error: 'login_required' }), { status: 401, headers: h });
+  }
+
+  if (!env.AUTH_KV) {
+    return new Response(JSON.stringify({ ok: false, error: 'kv_not_bound' }), { status: 500, headers: h });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ ok: false, error: 'invalid_json' }), { status: 400, headers: h });
+  }
+
+  const note = String(body.note || '').trim().slice(0, MAX_NOTE_LEN);
+  if (!note) {
+    return new Response(JSON.stringify({ ok: false, error: 'note_required' }), { status: 400, headers: h });
+  }
+
+  let categories = [];
+  if (Array.isArray(body.categories)) {
+    categories = body.categories.filter(c => ALLOWED_CATEGORIES.includes(c));
+  }
+
+  let recentMessages = [];
+  if (body.include_recent && Array.isArray(body.recent_messages)) {
+    recentMessages = body.recent_messages
+      .slice(-MAX_RECENT_MESSAGES)
+      .map(m => ({
+        role: String(m.role || '').slice(0, 20),
+        text: String(m.text || '').slice(0, MAX_MESSAGE_LEN),
+      }));
+  }
+
+  const login = (user.login || user.id || 'unknown').toString().toLowerCase();
+  const now = new Date().toISOString();
+  const ts = Date.now();
+  const rid = randomId();
+  const kvKey = `buddy-thread-report:${login}:${ts}:${rid}`;
+
+  const report = {
+    login,
+    user_id: user.id || null,
+    note,
+    categories,
+    include_recent: !!body.include_recent,
+    recent_messages: recentMessages,
+    thread_id: String(body.thread_id || 'primary').slice(0, 50),
+    url: String(body.url || '').slice(0, 200),
+    created_at: now,
+  };
+
+  await env.AUTH_KV.put(kvKey, JSON.stringify(report), {
+    expirationTtl: 60 * 60 * 24 * 365,
+  });
+
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers: h });
+}

--- a/functions/api/buddy-thread/report.js
+++ b/functions/api/buddy-thread/report.js
@@ -31,7 +31,8 @@ function responseHeaders(request) {
   const origin = request?.headers?.get('origin') || '';
   const allowed = /^https:\/\/(www\.)?aiit-threshold\.com$/i.test(origin)
     || /^https:\/\/[-a-z0-9]+\.buddy-bb4\.pages\.dev$/i.test(origin)
-    || /^https?:\/\/localhost(:\d+)?$/i.test(origin);
+    || /^https?:\/\/localhost(:\d+)?$/i.test(origin)
+    || /^https?:\/\/127\.0\.0\.1(:\d+)?$/i.test(origin);
   return {
     'Content-Type': 'application/json',
     ...(allowed ? {

--- a/functions/api/buddy-thread/thread.js
+++ b/functions/api/buddy-thread/thread.js
@@ -1,0 +1,99 @@
+// Cloudflare Pages Function: visible Buddy Thread account record.
+//
+// This is the user-facing thread store behind export/clear. It does not rewrite
+// Buddy's corpus, Kokoro memory, reports, or trained behavior.
+
+import {
+  clearBuddyThread,
+  getLoggedInUser,
+  loadBuddyThread,
+  publicBuddyThread,
+} from '../../_lib/buddyThread.js';
+
+function responseHeaders(request) {
+  const origin = request?.headers?.get('origin') || '';
+  const allowed = /^https:\/\/(www\.)?aiit-threshold\.com$/i.test(origin)
+    || /^https:\/\/[a-f0-9]+\.buddy-bb4\.pages\.dev$/i.test(origin)
+    || /^https:\/\/[-a-z0-9]+\.buddy-bb4\.pages\.dev$/i.test(origin)
+    || /^https?:\/\/localhost(:\d+)?$/i.test(origin)
+    || /^https?:\/\/127\.0\.0\.1(:\d+)?$/i.test(origin);
+  return {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    ...(allowed ? {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Methods': 'GET, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Credentials': 'true',
+      'Vary': 'Origin',
+    } : {}),
+  };
+}
+
+function json(request, data, status = 200) {
+  return new Response(JSON.stringify(data), { status, headers: responseHeaders(request) });
+}
+
+export async function onRequestOptions(context) {
+  return new Response(null, { status: 204, headers: responseHeaders(context.request) });
+}
+
+async function requireUser(request, env) {
+  if (!env.AUTH_KV) return { error: 'auth_kv_missing', status: 503 };
+  const user = await getLoggedInUser(request, env);
+  if (!user) return { error: 'login_required', status: 401 };
+  return { user };
+}
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const auth = await requireUser(request, env);
+  if (auth.error) return json(request, { ok: false, error: auth.error }, auth.status);
+
+  try {
+    const record = await loadBuddyThread(env, auth.user, 'primary');
+    return json(request, {
+      ok: true,
+      user: {
+        login: auth.user.login || null,
+        id: auth.user.id || null,
+        avatar_url: auth.user.avatar_url || null,
+      },
+      thread: publicBuddyThread(record),
+    });
+  } catch (err) {
+    return json(request, {
+      ok: false,
+      error: err && err.message ? err.message : 'failed_to_load_buddy_thread',
+    }, 500);
+  }
+}
+
+export async function onRequestDelete(context) {
+  const { request, env } = context;
+  const auth = await requireUser(request, env);
+  if (auth.error) return json(request, { ok: false, error: auth.error }, auth.status);
+
+  try {
+    const record = await clearBuddyThread(env, auth.user, 'primary');
+    return json(request, {
+      ok: true,
+      user: {
+        login: auth.user.login || null,
+        id: auth.user.id || null,
+        avatar_url: auth.user.avatar_url || null,
+      },
+      thread: publicBuddyThread(record),
+    });
+  } catch (err) {
+    return json(request, {
+      ok: false,
+      error: err && err.message ? err.message : 'failed_to_clear_buddy_thread',
+      user: {
+        login: auth.user.login || null,
+        id: auth.user.id || null,
+        avatar_url: auth.user.avatar_url || null,
+      },
+    }, 500);
+  }
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,31 @@
+/*
+  Cache-Control: public, max-age=0, s-maxage=86400, stale-while-revalidate=604800
+  X-Content-Type-Options: nosniff
+
+/sw.js
+  Cache-Control: no-cache, no-store, must-revalidate
+  Service-Worker-Allowed: /
+
+/snappy-nav.js
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/paper-game-sync.js
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=604800, stale-while-revalidate=604800
+
+/*.jpg
+  Cache-Control: public, max-age=604800, stale-while-revalidate=604800
+
+/*.jpeg
+  Cache-Control: public, max-age=604800, stale-while-revalidate=604800
+
+/*.svg
+  Cache-Control: public, max-age=604800, stale-while-revalidate=604800

--- a/public/paper-game-sync.js
+++ b/public/paper-game-sync.js
@@ -33,6 +33,18 @@
     return list(slugs).sort().join('|');
   }
 
+  async function postCollection(slugs) {
+    const res = await fetch(URL, {
+      method: 'POST',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ collected_slugs: list(slugs) })
+    });
+    if (!res.ok) throw new Error('collection_save_' + res.status);
+    return res.json();
+  }
+
   function escapeHtml(s) {
     return String(s || '').replace(/[&<>'"]/g, function (c) {
       return { '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[c];
@@ -102,42 +114,32 @@
     lastRemotePoll = now;
     syncing = true;
 
-    let data;
     try {
       const res = await fetch(URL, { credentials: 'same-origin', cache: 'no-store' });
       if (!res.ok) { fire(local, null); return; }
-      data = await res.json();
+      let data = await res.json();
+
+      if (!data || !data.user) {
+        fire(local, null);
+        return;
+      }
+
+      const merged = merge(local, data.collected_slugs);
+      if (snapshot(merged) !== snapshot(local)) writeLocal(merged);
+
+      if (snapshot(merged) !== snapshot(data.collected_slugs)) {
+        try { data = await postCollection(merged); } catch {}
+      }
+
+      const finalSlugs = list((data && data.collected_slugs) || merged);
+      writeLocal(finalSlugs);
+      lastSnapshot = snapshot(finalSlugs);
+      fire(finalSlugs, data && data.user);
     } catch {
       fire(local, null);
-      return;
     } finally {
       syncing = false;
     }
-
-    if (!data || !data.user) {
-      fire(local, null);
-      return;
-    }
-
-    const merged = merge(local, data.collected_slugs);
-    if (snapshot(merged) !== snapshot(local)) writeLocal(merged);
-
-    if (snapshot(merged) !== snapshot(data.collected_slugs)) {
-      try {
-        const save = await fetch(URL, {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ collected_slugs: merged })
-        });
-        if (save.ok) data = await save.json();
-      } catch {}
-    }
-
-    const finalSlugs = list((data && data.collected_slugs) || merged);
-    writeLocal(finalSlugs);
-    lastSnapshot = snapshot(finalSlugs);
-    fire(finalSlugs, data && data.user);
   }
 
   function saveUnlocked(slug) {
@@ -148,10 +150,36 @@
       writeLocal(current);
       fire(current, null);
     }
-    return sync(true);
+    return postCollection(current)
+      .then(function (data) {
+        const finalSlugs = merge(current, data && data.collected_slugs);
+        writeLocal(finalSlugs);
+        lastSnapshot = snapshot(finalSlugs);
+        fire(finalSlugs, data && data.user);
+        return finalSlugs;
+      })
+      .catch(function () {
+        return sync(true);
+      });
   }
 
-  window.BuddyPaperGameSync = { sync, saveUnlocked, readLocal };
+  function flush() {
+    const local = readLocal();
+    if (!local.length) return Promise.resolve(local);
+    return postCollection(local)
+      .then(function (data) {
+        const finalSlugs = merge(local, data && data.collected_slugs);
+        writeLocal(finalSlugs);
+        lastSnapshot = snapshot(finalSlugs);
+        fire(finalSlugs, data && data.user);
+        return finalSlugs;
+      })
+      .catch(function () {
+        return sync(true);
+      });
+  }
+
+  window.BuddyPaperGameSync = { sync, saveUnlocked, flush, readLocal };
 
   function start() {
     lastSnapshot = snapshot(readLocal());

--- a/public/snappy-nav.js
+++ b/public/snappy-nav.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  var VERSION = '2026-05-20.1';
+  var VERSION = '2026-05-20.2';
   var PREFETCH_LIMIT = 18;
   var HOVER_DELAY_MS = 45;
   var MAX_PREFETCH_AGE_MS = 10 * 60 * 1000;
@@ -39,10 +39,16 @@
       if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/cdn-cgi/')) return null;
       if (/\.(?:pdf|zip|mp4|webm|mp3|wav|jpg|jpeg|png|gif|svg|ico|css|js|json|xml|txt)$/i.test(url.pathname)) return null;
       url.hash = '';
+      if (needsTrailingSlash(url)) url.pathname += '/';
       return url;
     } catch (error) {
       return null;
     }
+  }
+
+  function needsTrailingSlash(url) {
+    if (url.pathname === '/' || url.pathname.endsWith('/')) return false;
+    return !/\.[a-z0-9]{2,5}$/i.test(url.pathname);
   }
 
   function linkUrl(anchor) {

--- a/public/snappy-nav.js
+++ b/public/snappy-nav.js
@@ -1,0 +1,211 @@
+(function () {
+  'use strict';
+
+  var VERSION = '2026-05-20.1';
+  var PREFETCH_LIMIT = 18;
+  var HOVER_DELAY_MS = 45;
+  var MAX_PREFETCH_AGE_MS = 10 * 60 * 1000;
+  var likelyPages = [
+    '/',
+    '/ask-buddy',
+    '/apps',
+    '/agentic',
+    '/lac',
+    '/voice2',
+    '/weather',
+    '/framework',
+    '/papers',
+    '/shop',
+    '/support',
+  ];
+
+  var prefetched = new Map();
+  var inFlight = new Map();
+  var hoverTimers = new WeakMap();
+  var linkHints = new Set();
+
+  function supportsFastPath() {
+    var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    if (!connection) return true;
+    if (connection.saveData) return false;
+    return !/2g/.test(connection.effectiveType || '');
+  }
+
+  function normalizeUrl(input) {
+    try {
+      var url = new URL(input, location.href);
+      if (url.origin !== location.origin) return null;
+      if (url.username || url.password) return null;
+      if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/cdn-cgi/')) return null;
+      if (/\.(?:pdf|zip|mp4|webm|mp3|wav|jpg|jpeg|png|gif|svg|ico|css|js|json|xml|txt)$/i.test(url.pathname)) return null;
+      url.hash = '';
+      return url;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function linkUrl(anchor) {
+    if (!anchor) return null;
+    var href = anchor.getAttribute('href');
+    if (!href || href[0] === '#') return null;
+    if (/^(?:mailto|tel|sms|javascript):/i.test(href)) return null;
+    if (anchor.target && anchor.target !== '_self') return null;
+    if (anchor.hasAttribute('download') || anchor.dataset.noPrefetch === 'true') return null;
+
+    var url = normalizeUrl(anchor.href);
+    if (!url) return null;
+    if (url.pathname === location.pathname && url.search === location.search) return null;
+    return url;
+  }
+
+  function touchTimestamp(url) {
+    prefetched.set(url.href, Date.now());
+    if (prefetched.size <= PREFETCH_LIMIT) return;
+    var oldestKey = null;
+    var oldestValue = Infinity;
+    prefetched.forEach(function (value, key) {
+      if (value < oldestValue) {
+        oldestValue = value;
+        oldestKey = key;
+      }
+    });
+    if (oldestKey) prefetched.delete(oldestKey);
+  }
+
+  function alreadyFresh(url) {
+    var seenAt = prefetched.get(url.href);
+    return seenAt && Date.now() - seenAt < MAX_PREFETCH_AGE_MS;
+  }
+
+  function addLinkHint(url) {
+    if (linkHints.has(url.href)) return;
+    linkHints.add(url.href);
+    var link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.href = url.href;
+    link.as = 'document';
+    link.crossOrigin = 'anonymous';
+    document.head.appendChild(link);
+  }
+
+  function prefetchUrl(url, reason) {
+    if (!url || !supportsFastPath()) return Promise.resolve(false);
+    if (alreadyFresh(url)) return Promise.resolve(true);
+    if (inFlight.has(url.href)) return inFlight.get(url.href);
+
+    addLinkHint(url);
+
+    var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    var timeout = controller ? setTimeout(function () { controller.abort(); }, 6000) : null;
+    var request = fetch(url.href, {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: {
+        'Accept': 'text/html,application/xhtml+xml',
+        'X-AIIT-Prefetch': reason || 'intent',
+      },
+      priority: reason === 'mousedown' ? 'high' : 'low',
+      signal: controller ? controller.signal : undefined,
+    })
+      .then(function (response) {
+        if (response && response.ok) {
+          touchTimestamp(url);
+          return true;
+        }
+        return false;
+      })
+      .catch(function () { return false; })
+      .finally(function () {
+        if (timeout) clearTimeout(timeout);
+        inFlight.delete(url.href);
+      });
+
+    inFlight.set(url.href, request);
+    return request;
+  }
+
+  function scheduleHover(anchor) {
+    if (hoverTimers.has(anchor)) return;
+    var timer = setTimeout(function () {
+      hoverTimers.delete(anchor);
+      prefetchUrl(linkUrl(anchor), 'hover');
+    }, HOVER_DELAY_MS);
+    hoverTimers.set(anchor, timer);
+  }
+
+  function cancelHover(anchor) {
+    var timer = hoverTimers.get(anchor);
+    if (!timer) return;
+    clearTimeout(timer);
+    hoverTimers.delete(anchor);
+  }
+
+  function anchorFromEvent(event) {
+    return event.target && event.target.closest ? event.target.closest('a[href]') : null;
+  }
+
+  function warmLikelyPages() {
+    if (!supportsFastPath()) return;
+    var queue = likelyPages
+      .map(normalizeUrl)
+      .filter(Boolean)
+      .filter(function (url) {
+        return !(url.pathname === location.pathname && url.search === location.search);
+      });
+
+    var run = function () {
+      var next = queue.shift();
+      if (!next) return;
+      prefetchUrl(next, 'idle').finally(function () {
+        setTimeout(run, 180);
+      });
+    };
+
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(run, { timeout: 2500 });
+    } else {
+      setTimeout(run, 1000);
+    }
+  }
+
+  function registerServiceWorker() {
+    if (!('serviceWorker' in navigator)) return;
+    if (!/^https?:$/.test(location.protocol)) return;
+    window.addEventListener('load', function () {
+      navigator.serviceWorker.register('/sw.js', { scope: '/' })
+        .then(function (registration) {
+          if (registration && registration.active) {
+            registration.active.postMessage({ type: 'AIIT_SNAPPY_VERSION', version: VERSION });
+          }
+        })
+        .catch(function () {});
+    }, { once: true });
+  }
+
+  document.addEventListener('pointerenter', function (event) {
+    var anchor = anchorFromEvent(event);
+    if (anchor) scheduleHover(anchor);
+  }, true);
+
+  document.addEventListener('pointerleave', function (event) {
+    var anchor = anchorFromEvent(event);
+    if (anchor) cancelHover(anchor);
+  }, true);
+
+  document.addEventListener('focusin', function (event) {
+    prefetchUrl(linkUrl(anchorFromEvent(event)), 'focus');
+  }, true);
+
+  document.addEventListener('touchstart', function (event) {
+    prefetchUrl(linkUrl(anchorFromEvent(event)), 'touch');
+  }, { capture: true, passive: true });
+
+  document.addEventListener('mousedown', function (event) {
+    if (event.button !== 0) return;
+    prefetchUrl(linkUrl(anchorFromEvent(event)), 'mousedown');
+  }, true);
+
+  registerServiceWorker();
+  warmLikelyPages();
+})();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var VERSION = '2026-05-20.1';
+var VERSION = '2026-05-20.2';
 var STATIC_CACHE = 'aiit-static-' + VERSION;
 var PAGE_CACHE = 'aiit-pages-' + VERSION;
 var RUNTIME_CACHE = 'aiit-runtime-' + VERSION;
@@ -80,9 +80,20 @@ function isRuntimeAsset(request, url) {
   return /\.(?:js|css|woff2?|png|jpg|jpeg|gif|svg|ico)$/i.test(url.pathname);
 }
 
-function cleanRequestUrl(request) {
+function canonicalPageUrl(request) {
   var url = new URL(request.url);
   url.hash = '';
+  if (needsTrailingSlash(url)) url.pathname += '/';
+  return url;
+}
+
+function needsTrailingSlash(url) {
+  if (url.pathname === '/' || url.pathname.endsWith('/')) return false;
+  return !/\.[a-z0-9]{2,5}$/i.test(url.pathname);
+}
+
+function cleanRequestUrl(request, url) {
+  url = url || new URL(request.url);
   return new Request(url.href, {
     method: 'GET',
     headers: request.headers,
@@ -93,7 +104,15 @@ function cleanRequestUrl(request) {
 }
 
 function staleWhileRevalidatePage(request) {
-  var cleanRequest = cleanRequestUrl(request);
+  var pageUrl = canonicalPageUrl(request);
+  var requestUrl = new URL(request.url);
+  requestUrl.hash = '';
+
+  if (request.mode === 'navigate' && pageUrl.href !== requestUrl.href) {
+    return Promise.resolve(Response.redirect(pageUrl.href, 308));
+  }
+
+  var cleanRequest = cleanRequestUrl(request, pageUrl);
   return caches.open(PAGE_CACHE).then(function (cache) {
     return cache.match(cleanRequest).then(function (cached) {
       var network = fetch(cleanRequest)

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var VERSION = '2026-05-20.1';
+var STATIC_CACHE = 'aiit-static-' + VERSION;
+var PAGE_CACHE = 'aiit-pages-' + VERSION;
+var RUNTIME_CACHE = 'aiit-runtime-' + VERSION;
+var MAX_PAGE_ENTRIES = 64;
+var MAX_RUNTIME_ENTRIES = 96;
+var CORE_ASSETS = [
+  '/',
+  '/snappy-nav.js',
+  '/paper-game-sync.js',
+  '/favicon.ico',
+  '/buddy-icon-64.png',
+  '/buddy-icon-192.png',
+  '/buddy-icon-512.png',
+];
+
+self.addEventListener('install', function (event) {
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then(function (cache) {
+        return Promise.all(CORE_ASSETS.map(function (url) {
+          return cache.add(url).catch(function () {});
+        }));
+      })
+      .then(function () { return self.skipWaiting(); })
+  );
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(
+    caches.keys()
+      .then(function (names) {
+        return Promise.all(names.map(function (name) {
+          if (name === STATIC_CACHE || name === PAGE_CACHE || name === RUNTIME_CACHE) return null;
+          if (/^aiit-(?:static|pages|runtime)-/.test(name)) return caches.delete(name);
+          return null;
+        }));
+      })
+      .then(function () { return self.clients.claim(); })
+  );
+});
+
+self.addEventListener('message', function (event) {
+  if (!event.data || event.data.type !== 'AIIT_SNAPPY_VERSION') return;
+  VERSION = event.data.version || VERSION;
+});
+
+self.addEventListener('fetch', function (event) {
+  var request = event.request;
+  if (!request || request.method !== 'GET') return;
+
+  var url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/cdn-cgi/')) return;
+
+  if (isHtmlRequest(request, url)) {
+    event.respondWith(staleWhileRevalidatePage(request));
+    return;
+  }
+
+  if (isRuntimeAsset(request, url)) {
+    event.respondWith(cacheFirstRuntime(request));
+  }
+});
+
+function isHtmlRequest(request, url) {
+  if (request.mode === 'navigate') return true;
+  var accept = request.headers.get('accept') || '';
+  if (!accept.includes('text/html')) return false;
+  return !/\.[a-z0-9]{2,5}$/i.test(url.pathname) || /\.html$/i.test(url.pathname);
+}
+
+function isRuntimeAsset(request, url) {
+  if (url.pathname.startsWith('/papers/') || url.pathname.startsWith('/letters/')) return false;
+  if (/\.(?:pdf|zip|mp4|webm|mp3|wav)$/i.test(url.pathname)) return false;
+  if (url.pathname.startsWith('/_astro/')) return true;
+  if (['script', 'style', 'font', 'image'].includes(request.destination)) return true;
+  return /\.(?:js|css|woff2?|png|jpg|jpeg|gif|svg|ico)$/i.test(url.pathname);
+}
+
+function cleanRequestUrl(request) {
+  var url = new URL(request.url);
+  url.hash = '';
+  return new Request(url.href, {
+    method: 'GET',
+    headers: request.headers,
+    mode: request.mode === 'navigate' ? 'same-origin' : request.mode,
+    credentials: request.credentials,
+    redirect: 'follow',
+  });
+}
+
+function staleWhileRevalidatePage(request) {
+  var cleanRequest = cleanRequestUrl(request);
+  return caches.open(PAGE_CACHE).then(function (cache) {
+    return cache.match(cleanRequest).then(function (cached) {
+      var network = fetch(cleanRequest)
+        .then(function (response) {
+          if (canCache(response)) {
+            cache.put(cleanRequest, response.clone());
+            trimCache(PAGE_CACHE, MAX_PAGE_ENTRIES);
+          }
+          return response;
+        })
+        .catch(function () { return cached; });
+
+      return cached || network;
+    });
+  });
+}
+
+function cacheFirstRuntime(request) {
+  var cleanRequest = cleanRequestUrl(request);
+  return caches.open(RUNTIME_CACHE).then(function (cache) {
+    return cache.match(cleanRequest).then(function (cached) {
+      if (cached) return cached;
+      return fetch(cleanRequest).then(function (response) {
+        if (canCache(response)) {
+          cache.put(cleanRequest, response.clone());
+          trimCache(RUNTIME_CACHE, MAX_RUNTIME_ENTRIES);
+        }
+        return response;
+      });
+    });
+  });
+}
+
+function canCache(response) {
+  if (!response || !response.ok) return false;
+  if (response.type !== 'basic') return false;
+  var cc = response.headers.get('cache-control') || '';
+  return !/no-store/i.test(cc);
+}
+
+function trimCache(cacheName, maxEntries) {
+  caches.open(cacheName)
+    .then(function (cache) {
+      return cache.keys().then(function (keys) {
+        if (keys.length <= maxEntries) return null;
+        return Promise.all(keys.slice(0, keys.length - maxEntries).map(function (key) {
+          return cache.delete(key);
+        }));
+      });
+    })
+    .catch(function () {});
+}

--- a/scripts/inject-paper-game-sync.mjs
+++ b/scripts/inject-paper-game-sync.mjs
@@ -10,7 +10,13 @@ function walk(dir) {
   const out = [];
   for (const name of readdirSync(dir)) {
     const path = join(dir, name);
-    const st = statSync(path);
+    let st;
+    try {
+      st = statSync(path);
+    } catch (err) {
+      if (err && err.code === 'ENOENT') continue;
+      throw err;
+    }
     if (st.isDirectory()) out.push(...walk(path));
     else if (name.endsWith('.html')) out.push(path);
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -365,6 +365,30 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
         '<svg class="gh-mark" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">' +
         '<path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>' +
         '</svg>';
+      function escHtml(value) {
+        return String(value).replace(/[&<>"']/g, (c) => ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+        }[c]));
+      }
+      function safeLogin(user) {
+        return String((user && (user.login || user.id)) || 'user')
+          .replace(/[^a-z0-9_-]/gi, '')
+          .slice(0, 39) || 'user';
+      }
+      function avatarMarkup(user, login, size) {
+        const raw = user && typeof user.avatar_url === 'string' ? user.avatar_url : '';
+        const avatar = /^https?:\/\//i.test(raw) ? raw : '';
+        if (avatar) {
+          return '<img src="' + escHtml(avatar) + '" alt="" width="' + size + '" height="' + size + '">';
+        }
+        return '<span class="nav-avatar-fallback" style="--avatar-size:' + size + 'px">' +
+          escHtml(login.charAt(0).toUpperCase()) +
+        '</span>';
+      }
       try {
         const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
         if (!r.ok) return;
@@ -372,21 +396,23 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
         const here = encodeURIComponent(location.pathname + location.search + location.hash || '/');
         let desktopHTML, mobileHTML, topMobileHTML;
         if (d.user) {
+          const login = safeLogin(d.user);
+          const profileHref = 'https://github.com/' + encodeURIComponent(login);
           desktopHTML =
-            '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="nav-user" title="@' + d.user.login + '">' +
-              '<img src="' + d.user.avatar_url + '" alt="" width="22" height="22">' +
-              '<span>@' + d.user.login + '</span>' +
+            '<a href="' + profileHref + '" target="_blank" rel="noopener" class="nav-user" title="@' + escHtml(login) + '">' +
+              avatarMarkup(d.user, login, 22) +
+              '<span>@' + escHtml(login) + '</span>' +
             '</a>' +
             '<a href="/api/auth/logout" class="nav-logout" title="Log out">↗</a>';
           mobileHTML =
-            '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="mnav-user">' +
-              '<img src="' + d.user.avatar_url + '" alt="" width="28" height="28">' +
-              '<span>@' + d.user.login + '</span>' +
+            '<a href="' + profileHref + '" target="_blank" rel="noopener" class="mnav-user">' +
+              avatarMarkup(d.user, login, 28) +
+              '<span>@' + escHtml(login) + '</span>' +
             '</a>' +
             '<a href="/api/auth/logout" class="mnav-logout">Log out</a>';
           topMobileHTML =
-            '<a href="https://github.com/' + d.user.login + '" target="_blank" rel="noopener" class="nav-user-pill" title="@' + d.user.login + '">' +
-              '<img src="' + d.user.avatar_url + '" alt="" width="26" height="26">' +
+            '<a href="' + profileHref + '" target="_blank" rel="noopener" class="nav-user-pill" title="@' + escHtml(login) + '">' +
+              avatarMarkup(d.user, login, 26) +
             '</a>';
         } else {
           desktopHTML =

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -47,6 +47,7 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
   <meta name="twitter:title" content={title}>
   <meta name="twitter:description" content={description}>
   <meta name="twitter:image" content={ogImage}>
+  <link rel="preload" href="/snappy-nav.js" as="script">
   <script is:inline>
     // Fix cold-load hash scroll: smooth-scroll races initial paint and loses.
     // On DOMContentLoaded, if there's a hash, kill smooth-scroll momentarily,
@@ -280,6 +281,7 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
       let verbTimer = null;
       let shardTimer = null;
       let safetyTimer = null;
+      let openTimer = null;
       let vi = Math.floor(Math.random() * VERBS.length);
 
       function spawnShards(n) {
@@ -306,17 +308,21 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
       }
 
       function start() {
-        if (running) return;
-        running = true;
-        loader.classList.add('open');
-        verbEl.textContent = VERBS[vi];
-        verbTimer = setInterval(tick, 520);
-        shardTimer = setInterval(() => spawnShards(3), 1400);
-        // Safety: never let the overlay sit longer than 6s.
-        safetyTimer = setTimeout(stop, 6000);
+        if (running || openTimer) return;
+        openTimer = setTimeout(() => {
+          openTimer = null;
+          running = true;
+          loader.classList.add('open');
+          verbEl.textContent = VERBS[vi];
+          verbTimer = setInterval(tick, 520);
+          shardTimer = setInterval(() => spawnShards(3), 1400);
+          // Safety: never let the overlay sit longer than 6s.
+          safetyTimer = setTimeout(stop, 6000);
+        }, 140);
       }
 
       function stop() {
+        if (openTimer) { clearTimeout(openTimer); openTimer = null; }
         running = false;
         loader.classList.remove('open');
         if (verbTimer) { clearInterval(verbTimer); verbTimer = null; }
@@ -475,6 +481,7 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
 
   {!isHome && <GaryWidget />}
 
+  <script src="/snappy-nav.js" defer></script>
   <script src="/paper-game-sync.js" defer></script>
 
   <!-- Language picker modal -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -435,6 +435,26 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
     })();
   </script>
 
+  <script is:inline>
+    (function () {
+      document.addEventListener('click', async function (event) {
+        const link = event.target && event.target.closest ? event.target.closest('a[href="/api/auth/logout"]') : null;
+        if (!link || event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        const sync = window.BuddyPaperGameSync;
+        if (!sync || typeof sync.flush !== 'function') return;
+
+        event.preventDefault();
+        try {
+          await Promise.race([
+            sync.flush(),
+            new Promise(resolve => setTimeout(resolve, 1400)),
+          ]);
+        } catch {}
+        window.location.href = link.href;
+      }, true);
+    })();
+  </script>
+
   <main>
     <slot />
   </main>
@@ -454,6 +474,8 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
   </footer>
 
   {!isHome && <GaryWidget />}
+
+  <script src="/paper-game-sync.js" defer></script>
 
   <!-- Language picker modal -->
   <div id="lang-picker" class="lang-picker" role="dialog" aria-modal="true" aria-label="Choose language" hidden>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -105,7 +105,7 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
         <button class="nav-trigger" aria-haspopup="true" aria-expanded="false">Applications <span class="nav-caret">▾</span></button>
         <div class="nav-menu">
           <a href="/apps">All apps</a>
-          <a href="https://victim-advocate.onrender.com" target="_blank" rel="noopener">Victim Advocate</a>
+          <a href="https://victim-advocate.aiit-threshold.com" target="_blank" rel="noopener">Victim Advocate</a>
           <a href="/apps#debunker">Debunker</a>
           <a href="/apps#little-lairs">Little Lairs</a>
         </div>
@@ -175,7 +175,7 @@ const isHome = Astro.url.pathname === '/' || Astro.url.pathname === '';
     <div class="mm-section">
       <div class="mm-label">Applications</div>
       <a href="/apps">All apps</a>
-      <a href="https://victim-advocate.onrender.com" target="_blank" rel="noopener">Victim Advocate</a>
+      <a href="https://victim-advocate.aiit-threshold.com" target="_blank" rel="noopener">Victim Advocate</a>
       <a href="/apps#debunker">Debunker</a>
       <a href="/apps#little-lairs">Little Lairs</a>
     </div>

--- a/src/pages/apps.astro
+++ b/src/pages/apps.astro
@@ -150,7 +150,7 @@ import Layout from '../layouts/Layout.astro';
         </div>
         <div class="app-papers">Related: Paper 143</div>
         <div class="app-actions">
-          <a href="https://victim-advocate.onrender.com" target="_blank" rel="noopener" class="app-btn launch">Launch App →</a>
+          <a href="https://victim-advocate.aiit-threshold.com" target="_blank" rel="noopener" class="app-btn launch">Launch App →</a>
         </div>
       </div>
 

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -23,7 +23,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       <div class="bt-console-top">
         <div>
           <div class="bt-notice-badge">Buddy Thread alpha</div>
-          <h2>First look at persistent Buddy.</h2>
+          <h2>Talk with persistent Buddy.</h2>
         </div>
         <div class="bt-user-chip" id="bt-user-chip">checking login</div>
       </div>
@@ -44,9 +44,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
         </div>
       </div>
       <div class="bt-thread-preview" id="bt-thread-preview" hidden>
-        <div class="bt-thread-preview-title">Persistent Buddy Thread</div>
+        <div class="bt-thread-preview-title">Live Buddy Thread Window</div>
         <div class="bt-thread-list" id="bt-thread-list" aria-live="polite"></div>
         <div class="bt-thread-typing" id="bt-thread-typing" hidden></div>
+        <div class="bt-thread-composer-slot" id="bt-thread-composer-slot" hidden></div>
       </div>
       <div class="bt-actions">
         <a class="bt-login-btn" id="bt-login-btn" href="/api/auth/github/login?redirect=/ask-buddy" hidden>Activate Buddy Thread</a>
@@ -546,9 +547,31 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		  const threadPreviewEl = document.getElementById('bt-thread-preview');
 		  const threadListEl = document.getElementById('bt-thread-list');
 		  const threadTypingEl = document.getElementById('bt-thread-typing');
+		  const threadComposerSlot = document.getElementById('bt-thread-composer-slot');
+		  const askInputBlock = document.querySelector('.ask-input-block');
+		  const askPage = document.querySelector('.ask-page');
+		  const originalAskParent = askInputBlock ? askInputBlock.parentNode : null;
+		  const originalAskNext = askInputBlock ? askInputBlock.nextSibling : null;
 		  let buddyThreadEnabled = false;
 		  let visibleThreadMessages = [];
 		  let optimisticThreadMessages = [];
+
+		  function placeAskComposer(inThread) {
+		    if (!askInputBlock) return;
+		    askInputBlock.classList.toggle('in-thread', !!inThread);
+		    if (askPage) askPage.classList.toggle('buddy-thread-active', !!inThread);
+		    if (inThread && threadComposerSlot) {
+		      threadComposerSlot.hidden = false;
+		      if (askInputBlock.parentNode !== threadComposerSlot) {
+		        threadComposerSlot.appendChild(askInputBlock);
+		      }
+		      return;
+		    }
+		    if (threadComposerSlot) threadComposerSlot.hidden = true;
+		    if (originalAskParent && askInputBlock.parentNode !== originalAskParent) {
+		      originalAskParent.insertBefore(askInputBlock, originalAskNext);
+		    }
+		  }
 
 		  function scrollThreadToBottom() {
 		    if (!threadListEl) return;
@@ -565,7 +588,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		      empty.className = 'bt-thread-empty';
 		      empty.textContent = locked
 		        ? 'Sign in to activate the persistent Buddy Thread.'
-		        : 'No stored messages yet. Ask Buddy and the visible thread will start here.';
+		        : 'This is the live chat window. Send a message below and Buddy will keep this account-linked thread moving.';
 		      threadListEl.appendChild(empty);
 		      return;
 		    }
@@ -843,6 +866,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      buddyThreadEnabled = false;
 	      visibleThreadMessages = [];
 	      optimisticThreadMessages = [];
+	      placeAskComposer(false);
 	      if (userChip) userChip.textContent = 'login required';
 	      if (threadState) threadState.textContent = 'locked';
 	      if (threadCount) threadCount.textContent = '0';
@@ -856,6 +880,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    }
 
 	    buddyThreadEnabled = true;
+	    placeAskComposer(true);
 	    if (loginBtn) loginBtn.hidden = true;
 	    [reportBtn, exportBtn, clearBtn].forEach((btn) => {
 	      if (btn) btn.disabled = false;
@@ -866,7 +891,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    function applyThread(thread) {
 	      const count = thread && Number(thread.message_count || 0);
 	      if (threadCount) threadCount.textContent = String(count || 0);
-	      if (threadState) threadState.textContent = count ? 'live' : 'ready';
+	      if (threadState) threadState.textContent = 'live';
 	      const messages = Array.isArray(thread && thread.messages) ? thread.messages : [];
 	      visibleThreadMessages = messages;
 	      optimisticThreadMessages = [];
@@ -1074,15 +1099,20 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     margin-bottom: 22px;
   }
   .ask-mascot-mini { flex-shrink: 0; }
-  .ask-title-block { display: flex; flex-direction: column; }
+  .ask-title-block {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
   .ask-h1 {
     font-family: 'Georgia', serif;
-    font-size: clamp(34pt, 5.6vw, 56pt);
+    font-size: 72px;
     color: #1a1a1a;
     margin: 0;
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
     line-height: 1;
     font-weight: 800;
+    white-space: nowrap;
   }
   .ask-bang {
     color: #c83a08;
@@ -1454,6 +1484,51 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    border-color: rgba(240, 165, 0, 0.18);
 	    background: rgba(240, 165, 0, 0.07);
 	  }
+	  .bt-thread-composer-slot {
+	    margin-top: 12px;
+	    padding-top: 12px;
+	    border-top: 1px solid rgba(255, 247, 223, 0.14);
+	  }
+	  .bt-thread-composer-slot[hidden] {
+	    display: none;
+	  }
+	  .ask-input-block.in-thread {
+	    margin: 0;
+	  }
+	  .ask-input-block.in-thread .ask-form {
+	    gap: 8px;
+	  }
+	  .ask-input-block.in-thread .ask-input {
+	    min-width: 0;
+	    height: 50px;
+	    background: rgba(255, 247, 223, 0.96);
+	    border-color: rgba(240, 165, 0, 0.55);
+	    color: #1a1a1a;
+	    box-shadow: none;
+	  }
+	  .ask-input-block.in-thread .ask-input:focus {
+	    border-color: #f0a500;
+	    box-shadow: 0 0 0 3px rgba(240, 165, 0, 0.18);
+	  }
+	  .ask-input-block.in-thread .ask-btn {
+	    min-width: 92px;
+	    height: 50px;
+	    border-color: #f0a500;
+	    background: #f0a500;
+	    color: #1a1a1a;
+	    white-space: nowrap;
+	  }
+	  .ask-input-block.in-thread .ask-joke-link {
+	    display: none;
+	  }
+	  .ask-input-block.in-thread .ask-status {
+	    margin-top: 8px;
+	    color: rgba(255, 247, 223, 0.7);
+	  }
+	  .ask-page.buddy-thread-active .ask-response,
+	  .ask-page.buddy-thread-active .ask-planets {
+	    display: none;
+	  }
 	  .bt-actions {
 	    display: flex;
 	    flex-wrap: wrap;
@@ -1822,8 +1897,20 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    .ask-page { padding: 90px 5vw 60px; }
 	    .ask-head { gap: 12px; }
 	    .ask-mascot-mini :global(.buddy-mascot-canvas) { width: 76px !important; }
+	    .ask-h1 { font-size: 40px !important; }
+	    .ask-buddy-tagline { font-size: 16px; }
 	    .ask-input { font-size: 12pt; height: 48px; }
 	    .ask-btn { height: 48px; padding: 0 16px; font-size: 10pt; }
+	    .ask-input-block.in-thread .ask-form {
+	      display: grid;
+	      grid-template-columns: minmax(0, 1fr) 92px;
+	      gap: 8px;
+	    }
+	    .ask-input-block.in-thread .ask-btn {
+	      min-width: 0;
+	      width: 92px;
+	      padding: 0 10px;
+	    }
 	    .bt-console-top { flex-direction: column; }
 	    .bt-user-chip { max-width: 100%; }
 	    .bt-metrics { grid-template-columns: 1fr; }
@@ -1831,6 +1918,20 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    .bt-modal { padding: 20px 16px; }
 	    .bt-category-grid { grid-template-columns: 1fr; }
 	    .bt-actions { flex-direction: column; }
+	  }
+	  @media (max-width: 380px) {
+	    .ask-head { gap: 8px; }
+	    .ask-mascot-mini :global(.buddy-mascot-canvas) { width: 62px !important; }
+	    .ask-h1 { font-size: 34px !important; }
+	    .ask-buddy-tagline { font-size: 15px; }
+	  }
+	  @media (max-width: 340px) {
+	    .ask-input-block.in-thread .ask-form {
+	      grid-template-columns: 1fr;
+	    }
+	    .ask-input-block.in-thread .ask-btn {
+	      width: 100%;
+	    }
 	  }
 </style>
 

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -43,6 +43,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
           <small>memory review</small>
         </div>
       </div>
+      <div class="bt-thread-preview" id="bt-thread-preview" hidden>
+        <div class="bt-thread-preview-title">Visible Buddy Thread</div>
+        <div class="bt-thread-list" id="bt-thread-list"></div>
+      </div>
       <div class="bt-actions">
         <button type="button" class="bt-report-btn" id="bt-report-btn">Report weird behavior</button>
         <button type="button" class="bt-export-btn" id="bt-export-btn">Export thread</button>
@@ -59,6 +63,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       <button type="button" class="bt-modal-close" id="bt-modal-close" aria-label="Close">&times;</button>
       <h2 id="bt-modal-title">Report weird behavior</h2>
       <p class="bt-modal-sub">Reports are review material only. They do not auto-promote into Buddy's memory.</p>
+      <div class="bt-report-status" id="bt-report-status" role="status" aria-live="polite" hidden></div>
       <form id="bt-report-form" autocomplete="off">
         <label for="bt-report-note">What happened?</label>
         <textarea id="bt-report-note" class="bt-report-note" maxlength="2000" rows="4" placeholder="Describe what Buddy did that felt off..."></textarea>
@@ -712,10 +717,13 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    const exportBtn = document.getElementById('bt-export-btn');
 	    const clearBtn = document.getElementById('bt-clear-btn');
 	    const errorEl = document.getElementById('bt-report-error');
+	    const reportStatusEl = document.getElementById('bt-report-status');
 	    const userChip = document.getElementById('bt-user-chip');
 	    const threadState = document.getElementById('bt-thread-state');
 	    const threadCount = document.getElementById('bt-thread-count');
 	    const threadMessage = document.getElementById('bt-thread-message');
+	    const threadPreview = document.getElementById('bt-thread-preview');
+	    const threadList = document.getElementById('bt-thread-list');
 	    const includeRecentEl = document.getElementById('bt-include-recent');
 	    const noteEl = document.getElementById('bt-report-note');
 
@@ -732,7 +740,15 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    function threadErrorCopy(status, error) {
 	      if (status === 401 || error === 'login_required') return 'Your login expired. Refresh and log in again.';
 	      if (status === 503 || error === 'auth_kv_missing' || error === 'kv_not_bound') return 'Buddy Thread storage is not bound on this environment.';
+	      if (error === 'report_write_failed') return 'Report reached the server, but KV did not save it. Try again.';
 	      return 'Buddy Thread did not respond. Refresh and try again.';
+	    }
+
+	    function setReportStatus(message, kind = '') {
+	      if (!reportStatusEl) return;
+	      reportStatusEl.textContent = message || '';
+	      reportStatusEl.dataset.kind = kind;
+	      reportStatusEl.hidden = !message;
 	    }
 
 	    function applyThread(thread) {
@@ -740,6 +756,27 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      if (threadCount) threadCount.textContent = String(count || 0);
 	      if (threadState) threadState.textContent = count ? 'live' : 'ready';
 	      hydrateTurnHistory(thread && thread.messages);
+	      renderThreadPreview(thread && thread.messages);
+	    }
+
+	    function renderThreadPreview(messages) {
+	      if (!threadPreview || !threadList) return;
+	      const rows = Array.isArray(messages) ? messages.slice(-10) : [];
+	      threadPreview.hidden = rows.length === 0;
+	      threadList.innerHTML = '';
+	      rows.forEach((message) => {
+	        const item = document.createElement('div');
+	        item.className = 'bt-thread-item ' + (message.role === 'buddy' ? 'buddy' : 'user');
+	        const role = document.createElement('div');
+	        role.className = 'bt-thread-role';
+	        role.textContent = message.role === 'buddy' ? 'Buddy' : 'You';
+	        const text = document.createElement('div');
+	        text.className = 'bt-thread-text';
+	        text.textContent = message.text || '';
+	        item.appendChild(role);
+	        item.appendChild(text);
+	        threadList.appendChild(item);
+	      });
 	    }
 
 	    async function fetchVisibleThread({ quiet = false } = {}) {
@@ -764,6 +801,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      confirmEl.hidden = true;
 	      reportForm.hidden = false;
 	      errorEl.hidden = true;
+	      setReportStatus('', '');
 	      if (receiptEl) receiptEl.textContent = '';
 	      reportForm.reset();
 	      if (includeRecentEl) includeRecentEl.checked = true;
@@ -776,14 +814,25 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    if (confirmCloseBtn) confirmCloseBtn.addEventListener('click', closeModal);
 	    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
 
-	    reportForm.addEventListener('submit', async (e) => {
-	      e.preventDefault();
+	    let reportBusy = false;
+	    async function submitReport(e) {
+	      if (e) e.preventDefault();
+	      if (reportBusy) return;
 	      const note = noteEl.value.trim();
+	      const sendBtn = document.getElementById('bt-send-report');
 	      if (!note) {
-	        errorEl.textContent = 'Add a short note before sending.';
+	        const msg = 'Add a short note before sending.';
+	        errorEl.textContent = msg;
 	        errorEl.hidden = false;
+	        setReportStatus(msg, 'error');
+	        if (sendBtn) {
+	          const prev = sendBtn.textContent;
+	          sendBtn.textContent = 'Need note';
+	          setTimeout(() => { sendBtn.textContent = prev; }, 1200);
+	        }
 	        return;
 	      }
+	      reportBusy = true;
 	      const cats = Array.from(document.querySelectorAll('input[name="bt-cat"]:checked')).map(c => c.value);
 	      const includeRecent = includeRecentEl.checked;
 
@@ -794,10 +843,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	          ])
 	        : [];
 
-	      const sendBtn = document.getElementById('bt-send-report');
 	      sendBtn.disabled = true;
 	      sendBtn.textContent = 'Sending...';
 	      errorEl.hidden = true;
+	      setReportStatus('Sending report...', '');
 
 	      let res = null;
 	      let data = null;
@@ -820,13 +869,16 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
 	      sendBtn.disabled = false;
 	      sendBtn.textContent = 'Send report';
+	      reportBusy = false;
 
 	      if (!res || !res.ok || !data || !data.ok) {
-	        const knownError = data && ['login_required', 'auth_kv_missing', 'kv_not_bound'].includes(data.error);
-	        errorEl.textContent = (knownError || (res && (res.status === 401 || res.status === 503)))
+	        const knownError = data && ['login_required', 'auth_kv_missing', 'kv_not_bound', 'report_write_failed'].includes(data.error);
+	        const msg = (knownError || (res && (res.status === 401 || res.status === 503)))
 	          ? threadErrorCopy(res && res.status, data && data.error)
 	          : 'Report did not send. Copy your note or try again after refreshing.';
+	        errorEl.textContent = msg;
 	        errorEl.hidden = false;
+	        setReportStatus(msg, 'error');
 	        return;
 	      }
 
@@ -837,8 +889,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	          : 'receipt captured';
 	      }
 	      confirmEl.hidden = false;
+	      setReportStatus(data.report_id ? 'Report sent. Receipt: ' + data.report_id : 'Report sent.', 'ok');
 	      setThreadMessage('Report captured for manual review.', 'ok');
-	    });
+	    }
+	    reportForm.addEventListener('submit', submitReport);
+	    const sendReportBtn = document.getElementById('bt-send-report');
+	    if (sendReportBtn) sendReportBtn.addEventListener('click', submitReport);
 
 	    if (exportBtn) {
 	      exportBtn.addEventListener('click', async () => {
@@ -1216,6 +1272,60 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    color: rgba(255, 247, 223, 0.58);
 	    text-transform: uppercase;
 	  }
+	  .bt-thread-preview {
+	    margin: 14px 0 12px;
+	    padding: 12px;
+	    border: 1px solid rgba(255, 247, 223, 0.14);
+	    border-radius: 8px;
+	    background: rgba(255, 253, 245, 0.055);
+	  }
+	  .bt-thread-preview-title {
+	    margin-bottom: 10px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 8.5pt;
+	    letter-spacing: 0.08em;
+	    text-transform: uppercase;
+	    color: rgba(240, 165, 0, 0.9);
+	  }
+	  .bt-thread-list {
+	    display: grid;
+	    gap: 8px;
+	    max-height: 280px;
+	    overflow-y: auto;
+	    padding-right: 4px;
+	  }
+	  .bt-thread-item {
+	    display: grid;
+	    grid-template-columns: 58px minmax(0, 1fr);
+	    gap: 9px;
+	    align-items: start;
+	    padding: 8px 9px;
+	    border-radius: 7px;
+	    border: 1px solid rgba(255, 247, 223, 0.1);
+	    background: rgba(255, 253, 245, 0.055);
+	  }
+	  .bt-thread-item.buddy {
+	    border-color: rgba(240, 165, 0, 0.22);
+	    background: rgba(240, 165, 0, 0.08);
+	  }
+	  .bt-thread-role {
+	    font-family: 'Courier New', monospace;
+	    font-size: 8pt;
+	    letter-spacing: 0.04em;
+	    color: rgba(255, 247, 223, 0.56);
+	    text-transform: uppercase;
+	  }
+	  .bt-thread-item.buddy .bt-thread-role {
+	    color: #f0a500;
+	  }
+	  .bt-thread-text {
+	    min-width: 0;
+	    font-family: 'Georgia', serif;
+	    font-size: 10.5pt;
+	    line-height: 1.45;
+	    color: rgba(255, 247, 223, 0.86);
+	    overflow-wrap: anywhere;
+	  }
 	  .bt-actions {
 	    display: flex;
 	    flex-wrap: wrap;
@@ -1343,7 +1453,28 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    line-height: 1.45;
 	    color: #6a5a3a;
 	  }
-  .bt-modal label {
+	  .bt-report-status {
+	    margin: 0 0 14px;
+	    padding: 9px 11px;
+	    border-radius: 7px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    line-height: 1.45;
+	    color: #4a3a20;
+	    background: rgba(180, 138, 0, 0.08);
+	    border: 1px solid rgba(180, 138, 0, 0.18);
+	  }
+	  .bt-report-status[data-kind="ok"] {
+	    color: #146b40;
+	    background: rgba(43, 182, 115, 0.12);
+	    border-color: rgba(43, 182, 115, 0.3);
+	  }
+	  .bt-report-status[data-kind="error"] {
+	    color: #c83a08;
+	    background: rgba(200, 58, 8, 0.08);
+	    border-color: rgba(200, 58, 8, 0.24);
+	  }
+	  .bt-modal label {
     display: block;
     font-family: 'Courier New', monospace;
     font-size: 10pt;
@@ -1535,6 +1666,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    .bt-console-top { flex-direction: column; }
 	    .bt-user-chip { max-width: 100%; }
 	    .bt-metrics { grid-template-columns: 1fr; }
+	    .bt-thread-item { grid-template-columns: 1fr; }
 	    .bt-modal { padding: 20px 16px; }
 	    .bt-category-grid { grid-template-columns: 1fr; }
 	    .bt-actions { flex-direction: column; }

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -20,37 +20,81 @@ import BuddyMascot from '../components/BuddyMascot.astro';
   <!-- EARLY ACCESS NOTICE — logged-in only -->
   <div class="bt-notice" id="bt-notice" hidden>
     <div class="bt-notice-inner">
-      <div class="bt-notice-badge">Early Buddy Thread access</div>
-      <p>You are one of the first people with a running conversation with Buddy.</p>
-      <p>This is experimental. Buddy may remember context, misread context, over-connect patterns, or act strange while the thread system is being tuned.</p>
-      <p>If something feels weird, report it. Weird is useful right now.</p>
+      <div class="bt-console-top">
+        <div>
+          <div class="bt-notice-badge">Buddy Thread alpha</div>
+          <h2>First look at persistent Buddy.</h2>
+        </div>
+        <div class="bt-user-chip" id="bt-user-chip">checking login</div>
+      </div>
+      <p class="bt-lede">This is not a search box. This is an early account-linked Buddy conversation with continuity, report capture, and manual memory review.</p>
+      <p>Buddy may remember context, misread context, over-connect patterns, or act strange while the thread system is being tuned.</p>
+      <div class="bt-metrics" aria-label="Buddy Thread status">
+        <div class="bt-metric">
+          <span id="bt-thread-state">checking</span>
+          <small>thread state</small>
+        </div>
+        <div class="bt-metric">
+          <span id="bt-thread-count">0</span>
+          <small>stored messages</small>
+        </div>
+        <div class="bt-metric">
+          <span>manual</span>
+          <small>memory review</small>
+        </div>
+      </div>
       <div class="bt-actions">
         <button type="button" class="bt-report-btn" id="bt-report-btn">Report weird behavior</button>
         <button type="button" class="bt-export-btn" id="bt-export-btn">Export thread</button>
         <button type="button" class="bt-clear-btn" id="bt-clear-btn">Clear thread</button>
       </div>
-      <a class="bt-policy-link" href="/data-policy">Data policy</a>
+      <div class="bt-thread-message" id="bt-thread-message" role="status" aria-live="polite" hidden></div>
+      <a class="bt-policy-link" href="/data-policy">Read the Buddy data policy -></a>
     </div>
   </div>
 
   <!-- REPORT MODAL -->
   <div class="bt-modal-overlay" id="bt-modal-overlay" hidden>
-    <div class="bt-modal" role="dialog" aria-labelledby="bt-modal-title">
+    <div class="bt-modal" role="dialog" aria-modal="true" aria-labelledby="bt-modal-title">
       <button type="button" class="bt-modal-close" id="bt-modal-close" aria-label="Close">&times;</button>
       <h2 id="bt-modal-title">Report weird behavior</h2>
+      <p class="bt-modal-sub">Reports are review material only. They do not auto-promote into Buddy's memory.</p>
       <form id="bt-report-form" autocomplete="off">
         <label for="bt-report-note">What happened?</label>
         <textarea id="bt-report-note" class="bt-report-note" maxlength="2000" rows="4" placeholder="Describe what Buddy did that felt off..."></textarea>
 
         <fieldset class="bt-categories">
-          <legend>Optional — what kind of weird?</legend>
-          <label><input type="checkbox" name="bt-cat" value="forgot_context"> Buddy forgot context</label>
-          <label><input type="checkbox" name="bt-cat" value="wrong_memory"> Buddy remembered wrong</label>
-          <label><input type="checkbox" name="bt-cat" value="overconnected"> Buddy over-connected things</label>
-          <label><input type="checkbox" name="bt-cat" value="strange_answer"> Buddy answered strangely</label>
-          <label><input type="checkbox" name="bt-cat" value="stuck_loop"> Buddy got stuck / repeated itself</label>
-          <label><input type="checkbox" name="bt-cat" value="unsafe"> Something felt unsafe</label>
-          <label><input type="checkbox" name="bt-cat" value="other"> Other</label>
+          <legend>Classify the failure</legend>
+          <div class="bt-category-grid">
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="forgot_context">
+              <span><strong>Forgot context</strong><small>Lost something already established.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="wrong_memory">
+              <span><strong>Wrong memory</strong><small>Remembered something incorrectly.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="overconnected">
+              <span><strong>Over-connected</strong><small>Linked patterns too aggressively.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="strange_answer">
+              <span><strong>Strange answer</strong><small>Awkward, broken, or off-tone.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="stuck_loop">
+              <span><strong>Loop or repeat</strong><small>Got stuck saying the same thing.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="unsafe">
+              <span><strong>Unsafe</strong><small>Something felt risky or wrong.</small></span>
+            </label>
+            <label class="bt-cat-option">
+              <input type="checkbox" name="bt-cat" value="other">
+              <span><strong>Other</strong><small>Anything that does not fit above.</small></span>
+            </label>
+          </div>
         </fieldset>
 
         <label class="bt-include-label">
@@ -423,14 +467,50 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     }
   }
 
-	  const MAX_HISTORY_PAIRS = 6;
-	  const turnHistory = [];
-	  function pushTurn(q, a) {
-	    turnHistory.push({ q, a });
-	    while (turnHistory.length > MAX_HISTORY_PAIRS) turnHistory.shift();
-	  }
+		  const MAX_HISTORY_PAIRS = 6;
+		  const turnHistory = [];
+		  let refreshBuddyThread = null;
+		  function pushTurn(q, a) {
+		    turnHistory.push({ q, a });
+		    while (turnHistory.length > MAX_HISTORY_PAIRS) turnHistory.shift();
+		  }
+		  function hydrateTurnHistory(messages) {
+		    if (!Array.isArray(messages)) return;
+		    const pairs = [];
+		    let pendingUser = null;
+		    messages.forEach((m) => {
+		      if (!m || typeof m.text !== 'string') return;
+		      if (m.role === 'user') {
+		        pendingUser = m.text;
+		      } else if (m.role === 'buddy' && pendingUser) {
+		        pairs.push({ q: pendingUser, a: m.text });
+		        pendingUser = null;
+		      }
+		    });
+		    turnHistory.length = 0;
+		    pairs.slice(-MAX_HISTORY_PAIRS).forEach(t => turnHistory.push(t));
+		  }
+		  function downloadJson(filename, data) {
+		    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+		    const a = document.createElement('a');
+		    a.href = URL.createObjectURL(blob);
+		    a.download = filename;
+		    a.style.display = 'none';
+		    document.body.appendChild(a);
+		    a.click();
+		    setTimeout(() => {
+		      URL.revokeObjectURL(a.href);
+		      a.remove();
+		    }, 250);
+		  }
+		  function noteThreadPayload(payload) {
+		    if (!payload || !payload.thread || !payload.thread.enabled) return;
+		    if (payload.thread.saved && refreshBuddyThread) {
+		      refreshBuddyThread({ quiet: true });
+		    }
+		  }
 
-	  const PENDING_STORAGE = 'askbuddy_pending_requests';
+		  const PENDING_STORAGE = 'askbuddy_pending_requests';
 	  const PENDING_POLL_MS = 3000;
 	  const PENDING_MAX_POLLS = 100;
 	  function loadPending() {
@@ -468,25 +548,29 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    if (!entry || !entry.request_id) return;
 	    let payload = null;
 	    try {
-	      const res = await fetch('/api/askbuddy_poll', {
-	        method: 'POST',
-	        headers: { 'content-type': 'application/json' },
-	        body: JSON.stringify({
-	          request_id: entry.request_id,
-	          session_id: entry.session_id,
-	        }),
-	      });
+		      const res = await fetch('/api/askbuddy_poll', {
+		        method: 'POST',
+		        credentials: 'same-origin',
+		        headers: { 'content-type': 'application/json' },
+		        body: JSON.stringify({
+		          request_id: entry.request_id,
+		          session_id: entry.session_id,
+		          question: entry.question || '',
+		          account_thread: !!entry.account_thread,
+		        }),
+		      });
 	      payload = await res.json();
 	    } catch {
 	      payload = { ok: false, error: 'network_failed' };
 	    }
 
 	    if (payload && payload.ok && payload.status === 'ready') {
-	      removePending(entry.request_id);
-	      pushTurn(entry.question || '', payload.answer || '');
-	      showFirstOutput(payload);
-	      return;
-	    }
+		      removePending(entry.request_id);
+		      pushTurn(entry.question || '', payload.answer || '');
+		      showFirstOutput(payload);
+		      noteThreadPayload(payload);
+		      return;
+		    }
 	    if (payload && payload.ok && payload.status === 'pending') {
 	      updatePendingMessage(attempt);
 	      if (attempt < PENDING_MAX_POLLS) {
@@ -525,11 +609,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     const t0 = performance.now();
     let payload = null;
     try {
-      const res = await fetch('/api/askbuddy', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          question: q,
+	      const res = await fetch('/api/askbuddy', {
+	        method: 'POST',
+	        credentials: 'same-origin',
+	        headers: { 'content-type': 'application/json' },
+	        body: JSON.stringify({
+	          question: q,
           fingerprint: getFingerprint(),
           session_id: getSessionId(),
           history: turnHistory.slice(),
@@ -546,21 +631,23 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       await new Promise(r => setTimeout(r, minShowMs - elapsed));
     }
 
-	    if (payload && payload.ok && payload.status === 'pending') {
-	      const entry = {
-	        request_id: payload.request_id,
-	        session_id: getSessionId(),
-	        question: q,
-	        ts: Date.now(),
-	      };
+		    if (payload && payload.ok && payload.status === 'pending') {
+		      const entry = {
+		        request_id: payload.request_id,
+		        session_id: payload.session_id || getSessionId(),
+		        question: q,
+		        account_thread: !!(payload.thread && payload.thread.enabled),
+		        ts: Date.now(),
+		      };
 	      addPending(entry);
 	      showPending(q);
 	      input.value = '';
 	      pollPending(entry, 0);
-	    } else if (payload && payload.ok) {
-	      pushTurn(q, payload.answer || '');
-	      showFirstOutput(payload);
-	      input.value = '';
+		    } else if (payload && payload.ok) {
+		      pushTurn(q, payload.answer || '');
+		      showFirstOutput(payload);
+		      noteThreadPayload(payload);
+		      input.value = '';
 	    } else if (payload && payload.error === 'daily_limit_reached') {
 	      showReply(payload.message || "you've used today's question. come back tomorrow.");
 	    } else if (payload && payload.error === 'budget_exhausted') {
@@ -601,119 +688,202 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     } catch {}
   })();
 
-  // --- BUDDY THREAD: auth check, report, export, clear ---
-  (async function initBuddyThread() {
-    let btUser = null;
-    try {
-      const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
-      const j = await r.json();
-      btUser = j && j.user ? j.user : null;
-    } catch {}
-    if (!btUser) return;
+	  // --- BUDDY THREAD: auth check, visible thread API, report, export, clear ---
+	  (async function initBuddyThread() {
+	    let btUser = null;
+	    try {
+	      const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
+	      const j = await r.json();
+	      btUser = j && j.user ? j.user : null;
+	    } catch {}
+	    if (!btUser) return;
 
-    const notice = document.getElementById('bt-notice');
-    if (notice) notice.hidden = false;
+	    const notice = document.getElementById('bt-notice');
+	    const overlay = document.getElementById('bt-modal-overlay');
+	    const reportBtn = document.getElementById('bt-report-btn');
+	    const closeBtn = document.getElementById('bt-modal-close');
+	    const reportForm = document.getElementById('bt-report-form');
+	    const confirmEl = document.getElementById('bt-report-confirm');
+	    const exportBtn = document.getElementById('bt-export-btn');
+	    const clearBtn = document.getElementById('bt-clear-btn');
+	    const errorEl = document.getElementById('bt-report-error');
+	    const userChip = document.getElementById('bt-user-chip');
+	    const threadState = document.getElementById('bt-thread-state');
+	    const threadCount = document.getElementById('bt-thread-count');
+	    const threadMessage = document.getElementById('bt-thread-message');
+	    const includeRecentEl = document.getElementById('bt-include-recent');
+	    const noteEl = document.getElementById('bt-report-note');
 
-    const overlay = document.getElementById('bt-modal-overlay');
-    const reportBtn = document.getElementById('bt-report-btn');
-    const closeBtn = document.getElementById('bt-modal-close');
-    const reportForm = document.getElementById('bt-report-form');
-    const confirmEl = document.getElementById('bt-report-confirm');
-    const exportBtn = document.getElementById('bt-export-btn');
-    const clearBtn = document.getElementById('bt-clear-btn');
+	    if (notice) notice.hidden = false;
+	    if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
 
-    function openModal() { overlay.hidden = false; confirmEl.hidden = true; reportForm.hidden = false; }
-    function closeModal() { overlay.hidden = true; }
+	    function setThreadMessage(message, kind = '') {
+	      if (!threadMessage) return;
+	      threadMessage.textContent = message || '';
+	      threadMessage.dataset.kind = kind;
+	      threadMessage.hidden = !message;
+	    }
 
-    reportBtn.addEventListener('click', openModal);
-    closeBtn.addEventListener('click', closeModal);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
+	    function threadErrorCopy(status, error) {
+	      if (status === 401 || error === 'login_required') return 'Your login expired. Refresh and log in again.';
+	      if (status === 503 || error === 'auth_kv_missing' || error === 'kv_not_bound') return 'Buddy Thread storage is not bound on this environment.';
+	      return 'Buddy Thread did not respond. Refresh and try again.';
+	    }
 
-    reportForm.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const note = document.getElementById('bt-report-note').value.trim();
-      if (!note) return;
-      const cats = Array.from(document.querySelectorAll('input[name="bt-cat"]:checked')).map(c => c.value);
-      const includeRecent = document.getElementById('bt-include-recent').checked;
+	    function applyThread(thread) {
+	      const count = thread && Number(thread.message_count || 0);
+	      if (threadCount) threadCount.textContent = String(count || 0);
+	      if (threadState) threadState.textContent = count ? 'live' : 'ready';
+	      hydrateTurnHistory(thread && thread.messages);
+	    }
 
-      const recentMessages = includeRecent
-        ? turnHistory.slice(-10).flatMap(t => [
-            { role: 'user', text: t.q },
-            { role: 'buddy', text: t.a },
-          ])
-        : [];
+	    async function fetchVisibleThread({ quiet = false } = {}) {
+	      if (!quiet && threadState) threadState.textContent = 'loading';
+	      const res = await fetch('/api/buddy-thread/thread', { credentials: 'same-origin' });
+	      const data = await res.json().catch(() => null);
+	      if (!res.ok || !data || !data.ok) {
+	        throw new Error(threadErrorCopy(res.status, data && data.error));
+	      }
+	      applyThread(data.thread);
+	      if (!quiet) setThreadMessage('Visible account thread loaded.', 'ok');
+	      return data;
+	    }
+	    refreshBuddyThread = fetchVisibleThread;
+	    fetchVisibleThread({ quiet: true }).catch((err) => {
+	      if (threadState) threadState.textContent = 'offline';
+	      setThreadMessage(err.message, 'error');
+	    });
 
-      const sendBtn = document.getElementById('bt-send-report');
-      const errorEl = document.getElementById('bt-report-error');
-      sendBtn.disabled = true;
-      sendBtn.textContent = 'Sending...';
-      errorEl.hidden = true;
+	    function openModal() {
+	      overlay.hidden = false;
+	      confirmEl.hidden = true;
+	      reportForm.hidden = false;
+	      errorEl.hidden = true;
+	      reportForm.reset();
+	      if (includeRecentEl) includeRecentEl.checked = true;
+	      requestAnimationFrame(() => noteEl && noteEl.focus());
+	    }
+	    function closeModal() { overlay.hidden = true; }
 
-      let res = null;
-      let data = null;
-      try {
-        res = await fetch('/api/buddy-thread/report', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            note,
-            categories: cats,
-            include_recent: includeRecent,
-            recent_messages: recentMessages,
-            thread_id: 'primary',
-            url: location.pathname,
-          }),
-        });
-        data = await res.json().catch(() => null);
-      } catch {}
+	    reportBtn.addEventListener('click', openModal);
+	    closeBtn.addEventListener('click', closeModal);
+	    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
 
-      sendBtn.disabled = false;
-      sendBtn.textContent = 'Send report';
+	    reportForm.addEventListener('submit', async (e) => {
+	      e.preventDefault();
+	      const note = noteEl.value.trim();
+	      if (!note) {
+	        errorEl.textContent = 'Add a short note before sending.';
+	        errorEl.hidden = false;
+	        return;
+	      }
+	      const cats = Array.from(document.querySelectorAll('input[name="bt-cat"]:checked')).map(c => c.value);
+	      const includeRecent = includeRecentEl.checked;
 
-      if (!res || !res.ok || !data || !data.ok) {
-        const loginExpired = res && res.status === 401;
-        errorEl.textContent = loginExpired
-          ? 'Your login expired. Refresh and log in again, then resend the report.'
-          : 'Report did not send. Copy your note or try again after refreshing.';
-        errorEl.hidden = false;
-        return;
-      }
+	      const recentMessages = includeRecent
+	        ? turnHistory.slice(-10).flatMap(t => [
+	            { role: 'user', text: t.q },
+	            { role: 'buddy', text: t.a },
+	          ])
+	        : [];
 
-      reportForm.hidden = true;
-      confirmEl.hidden = false;
-    });
+	      const sendBtn = document.getElementById('bt-send-report');
+	      sendBtn.disabled = true;
+	      sendBtn.textContent = 'Sending...';
+	      errorEl.hidden = true;
 
-    if (exportBtn) {
-      exportBtn.addEventListener('click', () => {
-        const data = {
-          user: btUser.login || btUser.id,
-          exported_at: new Date().toISOString(),
-          turns: turnHistory.slice(),
-          session_id: getSessionId(),
-        };
-        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = 'buddy-thread-export.json';
-        a.click();
-        URL.revokeObjectURL(a.href);
-      });
-    }
+	      let res = null;
+	      let data = null;
+	      try {
+	        res = await fetch('/api/buddy-thread/report', {
+	          method: 'POST',
+	          credentials: 'same-origin',
+	          headers: { 'content-type': 'application/json' },
+	          body: JSON.stringify({
+	            note,
+	            categories: cats,
+	            include_recent: includeRecent,
+	            recent_messages: recentMessages,
+	            thread_id: 'primary',
+	            url: location.pathname,
+	          }),
+	        });
+	        data = await res.json().catch(() => null);
+	      } catch {}
 
-    if (clearBtn) {
-      clearBtn.addEventListener('click', () => {
-        if (!confirm('Clear your visible thread history? This does not undo Kokoro memories Buddy has already formed.')) return;
-        turnHistory.length = 0;
-        try {
-          localStorage.removeItem(SESSION_STORAGE);
-          localStorage.removeItem(PENDING_STORAGE);
-        } catch {}
-        const resp = document.getElementById('ask-response');
-        if (resp) { resp.className = 'ask-response'; resp.innerHTML = ''; }
-      });
-    }
-  })();
+	      sendBtn.disabled = false;
+	      sendBtn.textContent = 'Send report';
+
+	      if (!res || !res.ok || !data || !data.ok) {
+	        const knownError = data && ['login_required', 'auth_kv_missing', 'kv_not_bound'].includes(data.error);
+	        errorEl.textContent = (knownError || (res && (res.status === 401 || res.status === 503)))
+	          ? threadErrorCopy(res && res.status, data && data.error)
+	          : 'Report did not send. Copy your note or try again after refreshing.';
+	        errorEl.hidden = false;
+	        return;
+	      }
+
+	      reportForm.hidden = true;
+	      confirmEl.hidden = false;
+	      setThreadMessage('Report captured for manual review.', 'ok');
+	    });
+
+	    if (exportBtn) {
+	      exportBtn.addEventListener('click', async () => {
+	        const prev = exportBtn.textContent;
+	        exportBtn.disabled = true;
+	        exportBtn.textContent = 'Exporting...';
+	        setThreadMessage('Preparing visible thread export...', '');
+	        try {
+	          const data = await fetchVisibleThread({ quiet: true });
+	          downloadJson('buddy-thread-export.json', {
+	            exported_at: new Date().toISOString(),
+	            user: data.user,
+	            thread: data.thread,
+	            limits: 'This export is the visible account thread only. Corpus records, reports, and Kokoro memory are separate.',
+	          });
+	          setThreadMessage('Visible account thread exported.', 'ok');
+	        } catch (err) {
+	          setThreadMessage(err.message || 'Export failed. Refresh and try again.', 'error');
+	        } finally {
+	          exportBtn.disabled = false;
+	          exportBtn.textContent = prev;
+	        }
+	      });
+	    }
+
+	    if (clearBtn) {
+	      clearBtn.addEventListener('click', async () => {
+	        if (!confirm('Clear the visible Buddy Thread for this login? This does not remove corpus logs, reviewed reports, or Kokoro memories Buddy may have formed.')) return;
+	        const prev = clearBtn.textContent;
+	        clearBtn.disabled = true;
+	        clearBtn.textContent = 'Clearing...';
+	        setThreadMessage('Clearing visible account thread...', '');
+	        try {
+	          const res = await fetch('/api/buddy-thread/thread', {
+	            method: 'DELETE',
+	            credentials: 'same-origin',
+	          });
+	          const data = await res.json().catch(() => null);
+	          if (!res.ok || !data || !data.ok) throw new Error(threadErrorCopy(res.status, data && data.error));
+	          applyThread(data.thread);
+	          turnHistory.length = 0;
+	          try {
+	            localStorage.removeItem(SESSION_STORAGE);
+	            localStorage.removeItem(PENDING_STORAGE);
+	          } catch {}
+	          const resp = document.getElementById('ask-response');
+	          if (resp) { resp.className = 'ask-response'; resp.innerHTML = ''; }
+	          setThreadMessage('Visible account thread cleared.', 'ok');
+	        } catch (err) {
+	          setThreadMessage(err.message || 'Clear failed. Refresh and try again.', 'error');
+	        } finally {
+	          clearBtn.disabled = false;
+	          clearBtn.textContent = prev;
+	        }
+	      });
+	    }
+	  })();
 })();
 </script>
 
@@ -934,89 +1104,185 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     margin-top: 4px;
   }
 
-  /* BUDDY THREAD NOTICE */
-  .bt-notice {
-    margin-bottom: 20px;
-    border: 1.5px solid rgba(200, 58, 8, 0.2);
-    border-radius: 10px;
-    background: rgba(200, 58, 8, 0.04);
-    overflow: hidden;
-  }
-  .bt-notice-inner {
-    padding: 16px 20px;
-  }
-  .bt-notice-badge {
-    display: inline-block;
-    font-family: 'Courier New', monospace;
-    font-size: 9pt;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: #c83a08;
-    background: rgba(200, 58, 8, 0.08);
-    padding: 3px 10px;
-    border-radius: 4px;
-    margin-bottom: 10px;
-  }
-  .bt-notice p {
-    font-family: 'Georgia', serif;
-    font-size: 11pt;
-    color: #4a3a20;
-    line-height: 1.6;
-    margin: 0 0 6px;
-  }
-  .bt-notice p:last-of-type {
-    margin-bottom: 14px;
-  }
-  .bt-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
-  .bt-report-btn {
-    background: #1a1a1a;
-    color: #f0a500;
-    border: 1.5px solid #1a1a1a;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-family: 'Courier New', monospace;
-    font-size: 10pt;
+	  /* BUDDY THREAD NOTICE */
+	  .bt-notice {
+	    margin-bottom: 22px;
+	    border: 1px solid rgba(240, 165, 0, 0.42);
+	    border-radius: 8px;
+	    background:
+	      linear-gradient(135deg, rgba(26, 26, 26, 0.98), rgba(55, 34, 17, 0.96)),
+	      #1a1a1a;
+	    overflow: hidden;
+	    box-shadow: 0 18px 40px rgba(40, 24, 10, 0.22);
+	  }
+	  .bt-notice-inner {
+	    padding: 20px;
+	  }
+	  .bt-console-top {
+	    display: flex;
+	    align-items: flex-start;
+	    justify-content: space-between;
+	    gap: 14px;
+	    margin-bottom: 12px;
+	  }
+	  .bt-notice-badge {
+	    display: inline-block;
+	    font-family: 'Courier New', monospace;
+	    font-size: 8.5pt;
+	    letter-spacing: 0.08em;
+	    text-transform: uppercase;
+	    color: #f0a500;
+	    background: rgba(240, 165, 0, 0.1);
+	    border: 1px solid rgba(240, 165, 0, 0.22);
+	    padding: 3px 10px;
+	    border-radius: 4px;
+	    margin-bottom: 8px;
+	  }
+	  .bt-notice h2 {
+	    margin: 0;
+	    font-family: 'Georgia', serif;
+	    font-size: clamp(16pt, 3.2vw, 24pt);
+	    line-height: 1.08;
+	    color: #fff7df;
+	    font-weight: 800;
+	  }
+	  .bt-user-chip {
+	    flex: 0 0 auto;
+	    max-width: 190px;
+	    overflow: hidden;
+	    text-overflow: ellipsis;
+	    white-space: nowrap;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    color: #1a1a1a;
+	    background: #f0a500;
+	    border: 1px solid rgba(255, 247, 223, 0.32);
+	    border-radius: 999px;
+	    padding: 6px 10px;
+	  }
+	  .bt-notice p {
+	    font-family: 'Georgia', serif;
+	    font-size: 11.5pt;
+	    color: rgba(255, 247, 223, 0.82);
+	    line-height: 1.55;
+	    margin: 0 0 8px;
+	  }
+	  .bt-notice .bt-lede {
+	    color: #fff7df;
+	    font-size: 12.5pt;
+	  }
+	  .bt-notice p:last-of-type {
+	    margin-bottom: 12px;
+	  }
+	  .bt-metrics {
+	    display: grid;
+	    grid-template-columns: repeat(3, minmax(0, 1fr));
+	    gap: 8px;
+	    margin: 14px 0;
+	  }
+	  .bt-metric {
+	    min-width: 0;
+	    background: rgba(255, 253, 245, 0.06);
+	    border: 1px solid rgba(255, 253, 245, 0.12);
+	    border-radius: 8px;
+	    padding: 10px;
+	  }
+	  .bt-metric span {
+	    display: block;
+	    overflow-wrap: anywhere;
+	    font-family: 'Courier New', monospace;
+	    font-size: 12pt;
+	    color: #f0a500;
+	    line-height: 1.1;
+	  }
+	  .bt-metric small {
+	    display: block;
+	    margin-top: 4px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 7.5pt;
+	    letter-spacing: 0.04em;
+	    color: rgba(255, 247, 223, 0.58);
+	    text-transform: uppercase;
+	  }
+	  .bt-actions {
+	    display: flex;
+	    flex-wrap: wrap;
+	    gap: 8px;
+	    margin: 12px 0 10px;
+	  }
+	  .bt-report-btn {
+	    background: #f0a500;
+	    color: #1a1a1a;
+	    border: 1.5px solid #f0a500;
+	    padding: 9px 16px;
+	    border-radius: 8px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 10pt;
     letter-spacing: 0.04em;
     cursor: pointer;
     transition: background 180ms, transform 120ms;
-  }
-  .bt-report-btn:hover {
-    background: #2a2a2a;
-    transform: translateY(-1px);
-  }
-  .bt-export-btn, .bt-clear-btn {
-    background: transparent;
-    color: #6a5a3a;
-    border: 1px solid rgba(106, 90, 58, 0.3);
-    padding: 8px 14px;
-    border-radius: 8px;
-    font-family: 'Courier New', monospace;
-    font-size: 9pt;
+	  }
+	  .bt-report-btn:hover {
+	    background: #ffd36a;
+	    border-color: #ffd36a;
+	    transform: translateY(-1px);
+	  }
+	  .bt-export-btn, .bt-clear-btn {
+	    background: rgba(255, 253, 245, 0.05);
+	    color: #fff7df;
+	    border: 1px solid rgba(255, 247, 223, 0.2);
+	    padding: 9px 14px;
+	    border-radius: 8px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
     letter-spacing: 0.04em;
     cursor: pointer;
-    transition: border-color 180ms, color 180ms;
-  }
-  .bt-export-btn:hover, .bt-clear-btn:hover {
-    color: #4a3a20;
-    border-color: rgba(106, 90, 58, 0.6);
-  }
-  .bt-policy-link {
-    font-family: 'Courier New', monospace;
-    font-size: 9pt;
-    color: #8a5a00;
-    text-decoration: none;
-    border-bottom: 1px solid rgba(138, 90, 0, 0.2);
-    letter-spacing: 0.04em;
-  }
-  .bt-policy-link:hover {
-    color: #c83a08;
-    border-color: rgba(200, 58, 8, 0.4);
-  }
+	    transition: border-color 180ms, color 180ms, background 180ms;
+	  }
+	  .bt-export-btn:hover, .bt-clear-btn:hover {
+	    color: #f0a500;
+	    border-color: rgba(240, 165, 0, 0.5);
+	    background: rgba(240, 165, 0, 0.08);
+	  }
+	  .bt-report-btn:disabled,
+	  .bt-export-btn:disabled,
+	  .bt-clear-btn:disabled {
+	    opacity: 0.58;
+	    cursor: progress;
+	  }
+	  .bt-thread-message {
+	    margin: 0 0 8px;
+	    padding: 8px 10px;
+	    border-radius: 6px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 8.5pt;
+	    line-height: 1.45;
+	    color: rgba(255, 247, 223, 0.78);
+	    background: rgba(255, 253, 245, 0.06);
+	    border: 1px solid rgba(255, 253, 245, 0.1);
+	  }
+	  .bt-thread-message[data-kind="ok"] {
+	    color: #b8ffd8;
+	    background: rgba(43, 182, 115, 0.12);
+	    border-color: rgba(43, 182, 115, 0.24);
+	  }
+	  .bt-thread-message[data-kind="error"] {
+	    color: #ffd0c4;
+	    background: rgba(200, 58, 8, 0.12);
+	    border-color: rgba(200, 58, 8, 0.26);
+	  }
+	  .bt-policy-link {
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    color: rgba(240, 165, 0, 0.9);
+	    text-decoration: none;
+	    border-bottom: 1px solid rgba(240, 165, 0, 0.28);
+	    letter-spacing: 0.04em;
+	  }
+	  .bt-policy-link:hover {
+	    color: #ffd36a;
+	    border-color: rgba(255, 211, 106, 0.5);
+	  }
 
   /* REPORT MODAL */
   .bt-modal-overlay {
@@ -1029,14 +1295,14 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     justify-content: center;
     padding: 20px;
   }
-  .bt-modal {
-    background: #fffdf5;
-    border: 1.5px solid rgba(180, 138, 0, 0.22);
-    border-radius: 14px;
-    max-width: 520px;
-    width: 100%;
-    max-height: 85vh;
-    overflow-y: auto;
+	  .bt-modal {
+	    background: #fffdf5;
+	    border: 1.5px solid rgba(180, 138, 0, 0.22);
+	    border-radius: 8px;
+	    max-width: 620px;
+	    width: 100%;
+	    max-height: 85vh;
+	    overflow-y: auto;
     padding: 28px 24px;
     position: relative;
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
@@ -1052,12 +1318,19 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     cursor: pointer;
     line-height: 1;
   }
-  .bt-modal h2 {
-    font-family: 'Georgia', serif;
-    font-size: 16pt;
-    color: #1a1a1a;
-    margin: 0 0 18px;
-  }
+	  .bt-modal h2 {
+	    font-family: 'Georgia', serif;
+	    font-size: 16pt;
+	    color: #1a1a1a;
+	    margin: 0 0 6px;
+	  }
+	  .bt-modal-sub {
+	    margin: 0 0 18px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    line-height: 1.45;
+	    color: #6a5a3a;
+	  }
   .bt-modal label {
     display: block;
     font-family: 'Courier New', monospace;
@@ -1089,28 +1362,56 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     padding: 0;
     margin: 0 0 16px;
   }
-  .bt-categories legend {
-    font-family: 'Courier New', monospace;
-    font-size: 10pt;
+	  .bt-categories legend {
+	    font-family: 'Courier New', monospace;
+	    font-size: 10pt;
     color: #6a5a3a;
-    letter-spacing: 0.04em;
-    margin-bottom: 8px;
-  }
-  .bt-categories label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: 'Georgia', serif;
-    font-size: 10.5pt;
-    color: #4a3a20;
-    margin-bottom: 5px;
-    cursor: pointer;
-  }
-  .bt-categories input[type="checkbox"] {
-    accent-color: #c83a08;
-    width: 16px;
-    height: 16px;
-  }
+	    letter-spacing: 0.04em;
+	    margin-bottom: 8px;
+	  }
+	  .bt-category-grid {
+	    display: grid;
+	    grid-template-columns: repeat(2, minmax(0, 1fr));
+	    gap: 8px;
+	  }
+	  .bt-categories label.bt-cat-option {
+	    display: flex;
+	    align-items: flex-start;
+	    gap: 8px;
+	    min-height: 58px;
+	    margin: 0;
+	    padding: 9px;
+	    border: 1px solid rgba(180, 138, 0, 0.18);
+	    border-radius: 8px;
+	    background: rgba(180, 138, 0, 0.04);
+	    cursor: pointer;
+	  }
+	  .bt-cat-option span {
+	    display: block;
+	    min-width: 0;
+	  }
+	  .bt-cat-option strong {
+	    display: block;
+	    font-family: 'Georgia', serif;
+	    font-size: 10.5pt;
+	    color: #2a2418;
+	    line-height: 1.2;
+	  }
+	  .bt-cat-option small {
+	    display: block;
+	    margin-top: 3px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 8pt;
+	    line-height: 1.35;
+	    color: #7a6a4a;
+	  }
+	  .bt-categories input[type="checkbox"] {
+	    accent-color: #c83a08;
+	    width: 16px;
+	    height: 16px;
+	    flex: 0 0 auto;
+	    margin-top: 2px;
+	  }
   .bt-include-label {
     display: flex !important;
     align-items: center;
@@ -1179,15 +1480,19 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     line-height: 1.5;
   }
 
-  @media (max-width: 620px) {
-    .ask-page { padding: 90px 5vw 60px; }
-    .ask-head { gap: 12px; }
-    .ask-mascot-mini :global(.buddy-mascot-canvas) { width: 76px !important; }
-    .ask-input { font-size: 12pt; height: 48px; }
-    .ask-btn { height: 48px; padding: 0 16px; font-size: 10pt; }
-    .bt-modal { padding: 20px 16px; }
-    .bt-actions { flex-direction: column; }
-  }
+	  @media (max-width: 620px) {
+	    .ask-page { padding: 90px 5vw 60px; }
+	    .ask-head { gap: 12px; }
+	    .ask-mascot-mini :global(.buddy-mascot-canvas) { width: 76px !important; }
+	    .ask-input { font-size: 12pt; height: 48px; }
+	    .ask-btn { height: 48px; padding: 0 16px; font-size: 10pt; }
+	    .bt-console-top { flex-direction: column; }
+	    .bt-user-chip { max-width: 100%; }
+	    .bt-metrics { grid-template-columns: 1fr; }
+	    .bt-modal { padding: 20px 16px; }
+	    .bt-category-grid { grid-template-columns: 1fr; }
+	    .bt-actions { flex-direction: column; }
+	  }
 </style>
 
 </Layout>

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -108,8 +108,11 @@ import BuddyMascot from '../components/BuddyMascot.astro';
           <button type="submit" class="bt-send-report" id="bt-send-report">Send report</button>
         </div>
       </form>
-      <div class="bt-report-confirm" id="bt-report-confirm" hidden>
-        Report sent. Thank you — this helps tune Buddy Thread.
+      <div class="bt-report-confirm" id="bt-report-confirm" role="status" aria-live="polite" hidden>
+        <strong>Report sent.</strong>
+        <span>Captured for manual AIIT review.</span>
+        <small id="bt-report-receipt"></small>
+        <button type="button" class="bt-confirm-close" id="bt-confirm-close">Close</button>
       </div>
       <div class="bt-report-error" id="bt-report-error" hidden></div>
     </div>
@@ -704,6 +707,8 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    const closeBtn = document.getElementById('bt-modal-close');
 	    const reportForm = document.getElementById('bt-report-form');
 	    const confirmEl = document.getElementById('bt-report-confirm');
+	    const confirmCloseBtn = document.getElementById('bt-confirm-close');
+	    const receiptEl = document.getElementById('bt-report-receipt');
 	    const exportBtn = document.getElementById('bt-export-btn');
 	    const clearBtn = document.getElementById('bt-clear-btn');
 	    const errorEl = document.getElementById('bt-report-error');
@@ -759,6 +764,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      confirmEl.hidden = true;
 	      reportForm.hidden = false;
 	      errorEl.hidden = true;
+	      if (receiptEl) receiptEl.textContent = '';
 	      reportForm.reset();
 	      if (includeRecentEl) includeRecentEl.checked = true;
 	      requestAnimationFrame(() => noteEl && noteEl.focus());
@@ -767,6 +773,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
 	    reportBtn.addEventListener('click', openModal);
 	    closeBtn.addEventListener('click', closeModal);
+	    if (confirmCloseBtn) confirmCloseBtn.addEventListener('click', closeModal);
 	    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
 
 	    reportForm.addEventListener('submit', async (e) => {
@@ -824,6 +831,11 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      }
 
 	      reportForm.hidden = true;
+	      if (receiptEl) {
+	        receiptEl.textContent = data.report_id
+	          ? 'receipt: ' + data.report_id
+	          : 'receipt captured';
+	      }
 	      confirmEl.hidden = false;
 	      setThreadMessage('Report captured for manual review.', 'ok');
 	    });
@@ -1460,15 +1472,49 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     opacity: 0.55;
     cursor: progress;
   }
-  .bt-report-confirm {
-    font-family: 'Georgia', serif;
-    font-size: 12pt;
-    color: #2bb673;
-    text-align: center;
-    padding: 24px 0;
-    line-height: 1.5;
-  }
-  .bt-report-error {
+	  .bt-report-confirm {
+	    font-family: 'Georgia', serif;
+	    font-size: 12pt;
+	    color: #1f7d4f;
+	    text-align: center;
+	    padding: 22px 14px;
+	    line-height: 1.5;
+	    background: rgba(43, 182, 115, 0.1);
+	    border: 1px solid rgba(43, 182, 115, 0.28);
+	    border-radius: 8px;
+	  }
+	  .bt-report-confirm strong {
+	    display: block;
+	    font-size: 17pt;
+	    color: #146b40;
+	    margin-bottom: 4px;
+	  }
+	  .bt-report-confirm span {
+	    display: block;
+	  }
+	  .bt-report-confirm small {
+	    display: block;
+	    margin: 10px 0 14px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    color: #4d6f5a;
+	    overflow-wrap: anywhere;
+	  }
+	  .bt-confirm-close {
+	    background: #1a1a1a;
+	    color: #f0a500;
+	    border: 1.5px solid #1a1a1a;
+	    padding: 9px 18px;
+	    border-radius: 8px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9.5pt;
+	    letter-spacing: 0.04em;
+	    cursor: pointer;
+	  }
+	  .bt-confirm-close:hover {
+	    background: #2a2a2a;
+	  }
+	  .bt-report-error {
     font-family: 'Courier New', monospace;
     font-size: 9.5pt;
     color: #c83a08;

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -44,8 +44,9 @@ import BuddyMascot from '../components/BuddyMascot.astro';
         </div>
       </div>
       <div class="bt-thread-preview" id="bt-thread-preview" hidden>
-        <div class="bt-thread-preview-title">Visible Buddy Thread</div>
-        <div class="bt-thread-list" id="bt-thread-list"></div>
+        <div class="bt-thread-preview-title">Persistent Buddy Thread</div>
+        <div class="bt-thread-list" id="bt-thread-list" aria-live="polite"></div>
+        <div class="bt-thread-typing" id="bt-thread-typing" hidden></div>
       </div>
       <div class="bt-actions">
         <a class="bt-login-btn" id="bt-login-btn" href="/api/auth/github/login?redirect=/ask-buddy" hidden>Activate Buddy Thread</a>
@@ -215,6 +216,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
   function startThinking() {
     setStatus('thinking', 'buddy thinking');
     setFlipSpeed(380); // planets speed up
+    if (buddyThreadEnabled) {
+      response.className = 'ask-response';
+      response.innerHTML = '';
+      setThreadTyping('buddy thinking...');
+      return;
+    }
 
     // proof of life within ~150ms
     response.className = 'ask-response loading visible';
@@ -239,6 +246,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
   function stopThinking() {
     if (thinkingTimer) { clearInterval(thinkingTimer); thinkingTimer = null; }
+    setThreadTyping('');
     setFlipSpeed(1100);
   }
 
@@ -333,6 +341,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    stopThinking();
 	    setStatus('online', 'buddy online');
 	    const answer = payload.answer || '';
+	    if (buddyThreadEnabled) {
+	      response.className = 'ask-response';
+	      response.innerHTML = '';
+	      appendThreadMessage('buddy', answer);
+	      return;
+	    }
     const obs = payload.observation || '';
     const cta = payload.cta || 'Pass it on';
     const strong = payload.observation_kind === 'substrate';
@@ -412,6 +426,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	  }
 
 	  function updatePendingMessage(attempt, networkIssue = false) {
+	    if (buddyThreadEnabled) {
+	      setThreadTyping(pendingMessage(attempt, networkIssue));
+	      return;
+	    }
 	    const pending = response.querySelector('.fo-pending');
 	    if (pending) pending.textContent = pendingMessage(attempt, networkIssue);
 	  }
@@ -420,6 +438,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    stopThinking();
 	    setStatus('thinking', 'buddy holding question');
 	    setFlipSpeed(520);
+	    if (buddyThreadEnabled) {
+	      response.className = 'ask-response';
+	      response.innerHTML = '';
+	      setThreadTyping(pendingMessage(attempt));
+	      return;
+	    }
 	    response.className = 'ask-response visible';
 	    response.innerHTML =
 	      '<div class="fo-block">' +
@@ -519,6 +543,66 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		    }
 		  }
 
+		  const threadPreviewEl = document.getElementById('bt-thread-preview');
+		  const threadListEl = document.getElementById('bt-thread-list');
+		  const threadTypingEl = document.getElementById('bt-thread-typing');
+		  let buddyThreadEnabled = false;
+		  let visibleThreadMessages = [];
+		  let optimisticThreadMessages = [];
+
+		  function scrollThreadToBottom() {
+		    if (!threadListEl) return;
+		    threadListEl.scrollTop = threadListEl.scrollHeight;
+		  }
+
+		  function renderThreadWindow({ locked = false } = {}) {
+		    if (!threadPreviewEl || !threadListEl) return;
+		    threadPreviewEl.hidden = false;
+		    threadListEl.innerHTML = '';
+		    const rows = locked ? [] : visibleThreadMessages.concat(optimisticThreadMessages).slice(-80);
+		    if (!rows.length) {
+		      const empty = document.createElement('div');
+		      empty.className = 'bt-thread-empty';
+		      empty.textContent = locked
+		        ? 'Sign in to activate the persistent Buddy Thread.'
+		        : 'No stored messages yet. Ask Buddy and the visible thread will start here.';
+		      threadListEl.appendChild(empty);
+		      return;
+		    }
+		    rows.forEach((message) => {
+		      const item = document.createElement('div');
+		      item.className = 'bt-thread-item ' + (message.role === 'buddy' ? 'buddy' : 'user');
+		      if (message.pending) item.classList.add('pending');
+		      const role = document.createElement('div');
+		      role.className = 'bt-thread-role';
+		      role.textContent = message.role === 'buddy' ? 'Buddy' : 'You';
+		      const text = document.createElement('div');
+		      text.className = 'bt-thread-text';
+		      text.textContent = message.text || '';
+		      item.appendChild(role);
+		      item.appendChild(text);
+		      threadListEl.appendChild(item);
+		    });
+		    requestAnimationFrame(scrollThreadToBottom);
+		  }
+
+		  function setThreadTyping(message) {
+		    if (!threadTypingEl) return;
+		    threadTypingEl.textContent = message || '';
+		    threadTypingEl.hidden = !message;
+		  }
+
+		  function appendThreadMessage(role, text) {
+		    if (!buddyThreadEnabled || !text) return;
+		    optimisticThreadMessages.push({
+		      role: role === 'buddy' ? 'buddy' : 'user',
+		      text,
+		      pending: true,
+		      at: new Date().toISOString(),
+		    });
+		    renderThreadWindow();
+		  }
+
 		  const PENDING_STORAGE = 'askbuddy_pending_requests';
 	  const PENDING_POLL_MS = 3000;
 	  const PENDING_MAX_POLLS = 100;
@@ -609,6 +693,9 @@ import BuddyMascot from '../components/BuddyMascot.astro';
   async function ask() {
     const q = input.value.trim();
     if (!q) return;
+    if (buddyThreadEnabled) {
+      appendThreadMessage('user', q);
+    }
     btn.disabled = true;
     btn.textContent = '...';
 
@@ -716,8 +803,6 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    const threadState = document.getElementById('bt-thread-state');
 	    const threadCount = document.getElementById('bt-thread-count');
 	    const threadMessage = document.getElementById('bt-thread-message');
-	    const threadPreview = document.getElementById('bt-thread-preview');
-	    const threadList = document.getElementById('bt-thread-list');
 	    const includeRecentEl = document.getElementById('bt-include-recent');
 	    const noteEl = document.getElementById('bt-report-note');
 
@@ -755,6 +840,9 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      btUser = j && j.user ? j.user : null;
 	    } catch {}
 	    if (!btUser) {
+	      buddyThreadEnabled = false;
+	      visibleThreadMessages = [];
+	      optimisticThreadMessages = [];
 	      if (userChip) userChip.textContent = 'login required';
 	      if (threadState) threadState.textContent = 'locked';
 	      if (threadCount) threadCount.textContent = '0';
@@ -762,42 +850,28 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      [reportBtn, exportBtn, clearBtn].forEach((btn) => {
 	        if (btn) btn.disabled = true;
 	      });
+	      renderThreadWindow({ locked: true });
 	      setThreadMessage('Sign in with GitHub to activate persistent Buddy Thread, reports, export, and clear controls.', '');
 	      return;
 	    }
 
+	    buddyThreadEnabled = true;
 	    if (loginBtn) loginBtn.hidden = true;
 	    [reportBtn, exportBtn, clearBtn].forEach((btn) => {
 	      if (btn) btn.disabled = false;
 	    });
 	    if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
+	    renderThreadWindow();
 
 	    function applyThread(thread) {
 	      const count = thread && Number(thread.message_count || 0);
 	      if (threadCount) threadCount.textContent = String(count || 0);
 	      if (threadState) threadState.textContent = count ? 'live' : 'ready';
-	      hydrateTurnHistory(thread && thread.messages);
-	      renderThreadPreview(thread && thread.messages);
-	    }
-
-	    function renderThreadPreview(messages) {
-	      if (!threadPreview || !threadList) return;
-	      const rows = Array.isArray(messages) ? messages.slice(-10) : [];
-	      threadPreview.hidden = rows.length === 0;
-	      threadList.innerHTML = '';
-	      rows.forEach((message) => {
-	        const item = document.createElement('div');
-	        item.className = 'bt-thread-item ' + (message.role === 'buddy' ? 'buddy' : 'user');
-	        const role = document.createElement('div');
-	        role.className = 'bt-thread-role';
-	        role.textContent = message.role === 'buddy' ? 'Buddy' : 'You';
-	        const text = document.createElement('div');
-	        text.className = 'bt-thread-text';
-	        text.textContent = message.text || '';
-	        item.appendChild(role);
-	        item.appendChild(text);
-	        threadList.appendChild(item);
-	      });
+	      const messages = Array.isArray(thread && thread.messages) ? thread.messages : [];
+	      visibleThreadMessages = messages;
+	      optimisticThreadMessages = [];
+	      hydrateTurnHistory(messages);
+	      renderThreadWindow();
 	    }
 
 	    async function fetchVisibleThread({ quiet = false } = {}) {
@@ -1309,11 +1383,13 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    color: rgba(240, 165, 0, 0.9);
 	  }
 	  .bt-thread-list {
-	    display: grid;
-	    gap: 8px;
-	    max-height: 280px;
+	    display: flex;
+	    flex-direction: column;
+	    gap: 10px;
+	    min-height: 160px;
+	    max-height: 360px;
 	    overflow-y: auto;
-	    padding-right: 4px;
+	    padding: 4px;
 	  }
 	  .bt-thread-item {
 	    display: grid;
@@ -1325,9 +1401,16 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    border: 1px solid rgba(255, 247, 223, 0.1);
 	    background: rgba(255, 253, 245, 0.055);
 	  }
+	  .bt-thread-item.user {
+	    background: rgba(255, 253, 245, 0.08);
+	  }
 	  .bt-thread-item.buddy {
 	    border-color: rgba(240, 165, 0, 0.22);
 	    background: rgba(240, 165, 0, 0.08);
+	  }
+	  .bt-thread-item.pending {
+	    opacity: 0.82;
+	    border-style: dashed;
 	  }
 	  .bt-thread-role {
 	    font-family: 'Courier New', monospace;
@@ -1346,6 +1429,30 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    line-height: 1.45;
 	    color: rgba(255, 247, 223, 0.86);
 	    overflow-wrap: anywhere;
+	  }
+	  .bt-thread-empty,
+	  .bt-thread-typing {
+	    min-height: 112px;
+	    display: flex;
+	    align-items: center;
+	    justify-content: center;
+	    padding: 16px;
+	    text-align: center;
+	    font-family: 'Courier New', monospace;
+	    font-size: 9pt;
+	    line-height: 1.5;
+	    color: rgba(255, 247, 223, 0.62);
+	    border: 1px dashed rgba(255, 247, 223, 0.14);
+	    border-radius: 7px;
+	    background: rgba(255, 253, 245, 0.035);
+	  }
+	  .bt-thread-typing {
+	    min-height: 0;
+	    justify-content: flex-start;
+	    margin-top: 10px;
+	    color: #f0a500;
+	    border-color: rgba(240, 165, 0, 0.18);
+	    background: rgba(240, 165, 0, 0.07);
 	  }
 	  .bt-actions {
 	    display: flex;
@@ -1451,6 +1558,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	  .bt-notice[hidden],
 	  .bt-login-btn[hidden],
 	  .bt-thread-preview[hidden],
+	  .bt-thread-typing[hidden],
 	  .bt-thread-message[hidden],
 	  .bt-modal-overlay[hidden],
 	  .bt-report-status[hidden],

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -67,6 +67,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       <div class="bt-report-confirm" id="bt-report-confirm" hidden>
         Report sent. Thank you — this helps tune Buddy Thread.
       </div>
+      <div class="bt-report-error" id="bt-report-error" hidden></div>
     </div>
   </div>
 
@@ -643,11 +644,15 @@ import BuddyMascot from '../components/BuddyMascot.astro';
         : [];
 
       const sendBtn = document.getElementById('bt-send-report');
+      const errorEl = document.getElementById('bt-report-error');
       sendBtn.disabled = true;
       sendBtn.textContent = 'Sending...';
+      errorEl.hidden = true;
 
+      let res = null;
+      let data = null;
       try {
-        await fetch('/api/buddy-thread/report', {
+        res = await fetch('/api/buddy-thread/report', {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'content-type': 'application/json' },
@@ -660,12 +665,23 @@ import BuddyMascot from '../components/BuddyMascot.astro';
             url: location.pathname,
           }),
         });
+        data = await res.json().catch(() => null);
       } catch {}
+
+      sendBtn.disabled = false;
+      sendBtn.textContent = 'Send report';
+
+      if (!res || !res.ok || !data || !data.ok) {
+        const loginExpired = res && res.status === 401;
+        errorEl.textContent = loginExpired
+          ? 'Your login expired. Refresh and log in again, then resend the report.'
+          : 'Report did not send. Copy your note or try again after refreshing.';
+        errorEl.hidden = false;
+        return;
+      }
 
       reportForm.hidden = true;
       confirmEl.hidden = false;
-      sendBtn.disabled = false;
-      sendBtn.textContent = 'Send report';
     });
 
     if (exportBtn) {
@@ -1149,6 +1165,17 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     color: #2bb673;
     text-align: center;
     padding: 24px 0;
+    line-height: 1.5;
+  }
+  .bt-report-error {
+    font-family: 'Courier New', monospace;
+    font-size: 9.5pt;
+    color: #c83a08;
+    background: rgba(200, 58, 8, 0.06);
+    border: 1px solid rgba(200, 58, 8, 0.2);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-top: 12px;
     line-height: 1.5;
   }
 

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -17,7 +17,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     </div>
   </header>
 
-  <!-- EARLY ACCESS NOTICE — logged-in only -->
+  <!-- EARLY ACCESS NOTICE / BUDDY THREAD CONSOLE -->
   <div class="bt-notice" id="bt-notice" hidden>
     <div class="bt-notice-inner">
       <div class="bt-console-top">
@@ -48,6 +48,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
         <div class="bt-thread-list" id="bt-thread-list"></div>
       </div>
       <div class="bt-actions">
+        <a class="bt-login-btn" id="bt-login-btn" href="/api/auth/github/login?redirect=/ask-buddy" hidden>Activate Buddy Thread</a>
         <button type="button" class="bt-report-btn" id="bt-report-btn">Report weird behavior</button>
         <button type="button" class="bt-export-btn" id="bt-export-btn">Export thread</button>
         <button type="button" class="bt-clear-btn" id="bt-clear-btn">Clear thread</button>
@@ -698,16 +699,9 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
 	  // --- BUDDY THREAD: auth check, visible thread API, report, export, clear ---
 	  (async function initBuddyThread() {
-	    let btUser = null;
-	    try {
-	      const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
-	      const j = await r.json();
-	      btUser = j && j.user ? j.user : null;
-	    } catch {}
-	    if (!btUser) return;
-
 	    const notice = document.getElementById('bt-notice');
 	    const overlay = document.getElementById('bt-modal-overlay');
+	    const loginBtn = document.getElementById('bt-login-btn');
 	    const reportBtn = document.getElementById('bt-report-btn');
 	    const closeBtn = document.getElementById('bt-modal-close');
 	    const reportForm = document.getElementById('bt-report-form');
@@ -728,7 +722,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    const noteEl = document.getElementById('bt-report-note');
 
 	    if (notice) notice.hidden = false;
-	    if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
+	    if (loginBtn) {
+	      const here = encodeURIComponent(location.pathname + location.search + location.hash || '/ask-buddy');
+	      loginBtn.href = '/api/auth/github/login?redirect=' + here;
+	    }
 
 	    function setThreadMessage(message, kind = '') {
 	      if (!threadMessage) return;
@@ -750,6 +747,30 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      reportStatusEl.dataset.kind = kind;
 	      reportStatusEl.hidden = !message;
 	    }
+
+	    let btUser = null;
+	    try {
+	      const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
+	      const j = await r.json();
+	      btUser = j && j.user ? j.user : null;
+	    } catch {}
+	    if (!btUser) {
+	      if (userChip) userChip.textContent = 'login required';
+	      if (threadState) threadState.textContent = 'locked';
+	      if (threadCount) threadCount.textContent = '0';
+	      if (loginBtn) loginBtn.hidden = false;
+	      [reportBtn, exportBtn, clearBtn].forEach((btn) => {
+	        if (btn) btn.disabled = true;
+	      });
+	      setThreadMessage('Sign in with GitHub to activate persistent Buddy Thread, reports, export, and clear controls.', '');
+	      return;
+	    }
+
+	    if (loginBtn) loginBtn.hidden = true;
+	    [reportBtn, exportBtn, clearBtn].forEach((btn) => {
+	      if (btn) btn.disabled = false;
+	    });
+	    if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
 
 	    function applyThread(thread) {
 	      const count = thread && Number(thread.message_count || 0);
@@ -1332,6 +1353,27 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    gap: 8px;
 	    margin: 12px 0 10px;
 	  }
+	  .bt-login-btn {
+	    display: inline-flex;
+	    align-items: center;
+	    justify-content: center;
+	    background: #f0a500;
+	    color: #1a1a1a;
+	    border: 1.5px solid #f0a500;
+	    padding: 9px 16px;
+	    border-radius: 8px;
+	    font-family: 'Courier New', monospace;
+	    font-size: 10pt;
+	    letter-spacing: 0.04em;
+	    text-decoration: none;
+	    cursor: pointer;
+	    transition: background 180ms, transform 120ms;
+	  }
+	  .bt-login-btn:hover {
+	    background: #ffd36a;
+	    border-color: #ffd36a;
+	    transform: translateY(-1px);
+	  }
 	  .bt-report-btn {
 	    background: #f0a500;
 	    color: #1a1a1a;
@@ -1344,7 +1386,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     cursor: pointer;
     transition: background 180ms, transform 120ms;
 	  }
-	  .bt-report-btn:hover {
+	  .bt-report-btn:hover:not(:disabled) {
 	    background: #ffd36a;
 	    border-color: #ffd36a;
 	    transform: translateY(-1px);
@@ -1361,7 +1403,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     cursor: pointer;
 	    transition: border-color 180ms, color 180ms, background 180ms;
 	  }
-	  .bt-export-btn:hover, .bt-clear-btn:hover {
+	  .bt-export-btn:hover:not(:disabled), .bt-clear-btn:hover:not(:disabled) {
 	    color: #f0a500;
 	    border-color: rgba(240, 165, 0, 0.5);
 	    background: rgba(240, 165, 0, 0.08);
@@ -1407,6 +1449,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	  }
 
 	  .bt-notice[hidden],
+	  .bt-login-btn[hidden],
 	  .bt-thread-preview[hidden],
 	  .bt-thread-message[hidden],
 	  .bt-modal-overlay[hidden],

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -1391,7 +1391,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    overflow-y: auto;
 	    padding: 4px;
 	  }
-	  .bt-thread-item {
+	  :global(.bt-thread-item) {
 	    display: grid;
 	    grid-template-columns: 58px minmax(0, 1fr);
 	    gap: 9px;
@@ -1401,28 +1401,28 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    border: 1px solid rgba(255, 247, 223, 0.1);
 	    background: rgba(255, 253, 245, 0.055);
 	  }
-	  .bt-thread-item.user {
+	  :global(.bt-thread-item.user) {
 	    background: rgba(255, 253, 245, 0.08);
 	  }
-	  .bt-thread-item.buddy {
+	  :global(.bt-thread-item.buddy) {
 	    border-color: rgba(240, 165, 0, 0.22);
 	    background: rgba(240, 165, 0, 0.08);
 	  }
-	  .bt-thread-item.pending {
+	  :global(.bt-thread-item.pending) {
 	    opacity: 0.82;
 	    border-style: dashed;
 	  }
-	  .bt-thread-role {
+	  :global(.bt-thread-role) {
 	    font-family: 'Courier New', monospace;
 	    font-size: 8pt;
 	    letter-spacing: 0.04em;
 	    color: rgba(255, 247, 223, 0.56);
 	    text-transform: uppercase;
 	  }
-	  .bt-thread-item.buddy .bt-thread-role {
+	  :global(.bt-thread-item.buddy .bt-thread-role) {
 	    color: #f0a500;
 	  }
-	  .bt-thread-text {
+	  :global(.bt-thread-text) {
 	    min-width: 0;
 	    font-family: 'Georgia', serif;
 	    font-size: 10.5pt;
@@ -1430,7 +1430,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    color: rgba(255, 247, 223, 0.86);
 	    overflow-wrap: anywhere;
 	  }
-	  .bt-thread-empty,
+	  :global(.bt-thread-empty),
 	  .bt-thread-typing {
 	    min-height: 112px;
 	    display: flex;
@@ -1827,7 +1827,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    .bt-console-top { flex-direction: column; }
 	    .bt-user-chip { max-width: 100%; }
 	    .bt-metrics { grid-template-columns: 1fr; }
-	    .bt-thread-item { grid-template-columns: 1fr; }
+	    :global(.bt-thread-item) { grid-template-columns: 1fr; }
 	    .bt-modal { padding: 20px 16px; }
 	    .bt-category-grid { grid-template-columns: 1fr; }
 	    .bt-actions { flex-direction: column; }

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -51,6 +51,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       </div>
       <div class="bt-actions">
         <a class="bt-login-btn" id="bt-login-btn" href="/api/auth/github/login?redirect=/ask-buddy" hidden>Activate Buddy Thread</a>
+        <button type="button" class="bt-demo-btn" id="bt-demo-btn" hidden>Preview chat window</button>
         <button type="button" class="bt-report-btn" id="bt-report-btn">Report weird behavior</button>
         <button type="button" class="bt-export-btn" id="bt-export-btn">Export thread</button>
         <button type="button" class="bt-clear-btn" id="bt-clear-btn">Clear thread</button>
@@ -199,6 +200,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
   const input    = document.getElementById('ask-input');
   const btn      = document.getElementById('ask-btn');
   const response = document.getElementById('ask-response');
+  const originalAskPlaceholder = input ? input.getAttribute('placeholder') || '' : '';
   const statusDot = document.getElementById('ask-status-dot');
   const statusText = document.getElementById('ask-status-text');
   const statusBlk  = document.getElementById('ask-status');
@@ -345,7 +347,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    if (buddyThreadEnabled) {
 	      response.className = 'ask-response';
 	      response.innerHTML = '';
-	      appendThreadMessage('buddy', answer);
+	      appendThreadMessage('buddy', answer, { pending: !buddyThreadDemoMode });
 	      return;
 	    }
     const obs = payload.observation || '';
@@ -553,12 +555,33 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		  const originalAskParent = askInputBlock ? askInputBlock.parentNode : null;
 		  const originalAskNext = askInputBlock ? askInputBlock.nextSibling : null;
 		  let buddyThreadEnabled = false;
+		  let buddyThreadDemoMode = false;
 		  let visibleThreadMessages = [];
 		  let optimisticThreadMessages = [];
+
+		  function isThreadPreviewHost() {
+		    const host = location.hostname;
+		    return host === 'localhost'
+		      || host === '127.0.0.1'
+		      || host.endsWith('.pages.dev');
+		  }
+
+		  function wantsThreadPreview() {
+		    const params = new URLSearchParams(location.search);
+		    const value = params.get('thread_preview') || params.get('preview_thread') || params.get('demo_thread');
+		    return value === '1' || value === 'true' || value === 'yes';
+		  }
+
+		  function threadPreviewUrl() {
+		    const next = new URL(location.href);
+		    next.searchParams.set('thread_preview', '1');
+		    return next.toString();
+		  }
 
 		  function placeAskComposer(inThread) {
 		    if (!askInputBlock) return;
 		    askInputBlock.classList.toggle('in-thread', !!inThread);
+		    if (input) input.placeholder = inThread ? 'Message Buddy...' : originalAskPlaceholder;
 		    if (askPage) askPage.classList.toggle('buddy-thread-active', !!inThread);
 		    if (inThread && threadComposerSlot) {
 		      threadComposerSlot.hidden = false;
@@ -583,6 +606,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		    threadPreviewEl.hidden = false;
 		    threadListEl.innerHTML = '';
 		    const rows = locked ? [] : visibleThreadMessages.concat(optimisticThreadMessages).slice(-80);
+		    if (!locked) {
+		      const countEl = document.getElementById('bt-thread-count');
+		      if (countEl) countEl.textContent = String(rows.length);
+		    }
 		    if (!rows.length) {
 		      const empty = document.createElement('div');
 		      empty.className = 'bt-thread-empty';
@@ -615,15 +642,72 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 		    threadTypingEl.hidden = !message;
 		  }
 
-		  function appendThreadMessage(role, text) {
+		  function appendThreadMessage(role, text, options = {}) {
 		    if (!buddyThreadEnabled || !text) return;
 		    optimisticThreadMessages.push({
 		      role: role === 'buddy' ? 'buddy' : 'user',
 		      text,
-		      pending: true,
+		      pending: options.pending !== false,
 		      at: new Date().toISOString(),
 		    });
 		    renderThreadWindow();
+		  }
+
+		  function demoBuddyAnswer(question) {
+		    const trimmed = String(question || '').trim();
+		    if (trimmed && /remember|context|tomorrow|day 200|persistent/i.test(trimmed)) {
+		      return 'Preview mode: this window is the persistent Buddy Thread surface. In a real login, Buddy reloads the same visible account thread instead of starting over.';
+		    }
+		    return 'Preview mode: this is the live chat layout without GitHub auth. A real logged-in thread sends this message to Buddy and can preserve the account-linked context across visits.';
+		  }
+
+		  function startThreadPreviewMode({
+		    loginBtn,
+		    demoBtn,
+		    reportBtn,
+		    exportBtn,
+		    clearBtn,
+		    userChip,
+		    threadState,
+		    setThreadMessage,
+		  }) {
+		    buddyThreadEnabled = true;
+		    buddyThreadDemoMode = true;
+		    const now = new Date().toISOString();
+		    visibleThreadMessages = [
+		      {
+		        role: 'user',
+		        text: 'Buddy, if I come back tomorrow, will this thread still know where we left off?',
+		        at: now,
+		      },
+		      {
+		        role: 'buddy',
+		        text: 'Yes. In a real logged-in Buddy Thread, this account-linked surface reloads the visible thread instead of treating every visit like day one.',
+		        at: now,
+		      },
+		      {
+		        role: 'user',
+		        text: 'So this is not the old Ask Buddy box?',
+		        at: now,
+		      },
+		      {
+		        role: 'buddy',
+		        text: 'Right. Ask Buddy still exists, but this window is the persistent conversation surface: continuity, reports, export, clear, and manual memory review.',
+		        at: now,
+		      },
+		    ];
+		    optimisticThreadMessages = [];
+		    hydrateTurnHistory(visibleThreadMessages);
+		    placeAskComposer(true);
+		    if (loginBtn) loginBtn.hidden = true;
+		    if (demoBtn) demoBtn.hidden = true;
+		    [reportBtn, exportBtn, clearBtn].forEach((btn) => {
+		      if (btn) btn.disabled = false;
+		    });
+		    if (userChip) userChip.textContent = '@preview';
+		    if (threadState) threadState.textContent = 'preview';
+		    renderThreadWindow();
+		    setThreadMessage('Preview mode only. This is not logged in, not saved, and not sent to Buddy.', '');
 		  }
 
 		  const PENDING_STORAGE = 'askbuddy_pending_requests';
@@ -717,7 +801,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     const q = input.value.trim();
     if (!q) return;
     if (buddyThreadEnabled) {
-      appendThreadMessage('user', q);
+      appendThreadMessage('user', q, { pending: !buddyThreadDemoMode });
     }
     btn.disabled = true;
     btn.textContent = '...';
@@ -727,6 +811,16 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     const minShowMs = 500;
     const t0 = performance.now();
     let payload = null;
+    if (buddyThreadDemoMode) {
+      await new Promise(r => setTimeout(r, minShowMs));
+      const answer = demoBuddyAnswer(q);
+      pushTurn(q, answer);
+      showFirstOutput({ ok: true, answer });
+      input.value = '';
+      btn.disabled = false;
+      btn.textContent = 'Ask →';
+      return;
+    }
     try {
 	      const res = await fetch('/api/askbuddy', {
 	        method: 'POST',
@@ -812,6 +906,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    const notice = document.getElementById('bt-notice');
 	    const overlay = document.getElementById('bt-modal-overlay');
 	    const loginBtn = document.getElementById('bt-login-btn');
+	    const demoBtn = document.getElementById('bt-demo-btn');
 	    const reportBtn = document.getElementById('bt-report-btn');
 	    const closeBtn = document.getElementById('bt-modal-close');
 	    const reportForm = document.getElementById('bt-report-form');
@@ -833,6 +928,10 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    if (loginBtn) {
 	      const here = encodeURIComponent(location.pathname + location.search + location.hash || '/ask-buddy');
 	      loginBtn.href = '/api/auth/github/login?redirect=' + here;
+	    }
+	    if (demoBtn && isThreadPreviewHost()) {
+	      demoBtn.hidden = false;
+	      demoBtn.addEventListener('click', () => { location.href = threadPreviewUrl(); });
 	    }
 
 	    function setThreadMessage(message, kind = '') {
@@ -863,30 +962,46 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      btUser = j && j.user ? j.user : null;
 	    } catch {}
 	    if (!btUser) {
-	      buddyThreadEnabled = false;
-	      visibleThreadMessages = [];
-	      optimisticThreadMessages = [];
-	      placeAskComposer(false);
-	      if (userChip) userChip.textContent = 'login required';
-	      if (threadState) threadState.textContent = 'locked';
-	      if (threadCount) threadCount.textContent = '0';
-	      if (loginBtn) loginBtn.hidden = false;
+	      if (isThreadPreviewHost() && wantsThreadPreview()) {
+	        startThreadPreviewMode({
+	          loginBtn,
+	          demoBtn,
+	          reportBtn,
+	          exportBtn,
+	          clearBtn,
+	          userChip,
+	          threadState,
+	          setThreadMessage,
+	        });
+	      } else {
+	        buddyThreadEnabled = false;
+	        buddyThreadDemoMode = false;
+	        visibleThreadMessages = [];
+	        optimisticThreadMessages = [];
+	        placeAskComposer(false);
+	        if (userChip) userChip.textContent = 'login required';
+	        if (threadState) threadState.textContent = 'locked';
+	        if (threadCount) threadCount.textContent = '0';
+	        if (loginBtn) loginBtn.hidden = false;
+	        [reportBtn, exportBtn, clearBtn].forEach((btn) => {
+	          if (btn) btn.disabled = true;
+	        });
+	        renderThreadWindow({ locked: true });
+	        setThreadMessage('Sign in with GitHub to activate persistent Buddy Thread, reports, export, and clear controls.', '');
+	        return;
+	      }
+	    } else {
+	      buddyThreadEnabled = true;
+	      buddyThreadDemoMode = false;
+	      placeAskComposer(true);
+	      if (loginBtn) loginBtn.hidden = true;
+	      if (demoBtn) demoBtn.hidden = true;
 	      [reportBtn, exportBtn, clearBtn].forEach((btn) => {
-	        if (btn) btn.disabled = true;
+	        if (btn) btn.disabled = false;
 	      });
-	      renderThreadWindow({ locked: true });
-	      setThreadMessage('Sign in with GitHub to activate persistent Buddy Thread, reports, export, and clear controls.', '');
-	      return;
+	      if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
+	      renderThreadWindow();
 	    }
-
-	    buddyThreadEnabled = true;
-	    placeAskComposer(true);
-	    if (loginBtn) loginBtn.hidden = true;
-	    [reportBtn, exportBtn, clearBtn].forEach((btn) => {
-	      if (btn) btn.disabled = false;
-	    });
-	    if (userChip) userChip.textContent = '@' + (btUser.login || btUser.id || 'logged-in');
-	    renderThreadWindow();
 
 	    function applyThread(thread) {
 	      const count = thread && Number(thread.message_count || 0);
@@ -911,10 +1026,12 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      return data;
 	    }
 	    refreshBuddyThread = fetchVisibleThread;
-	    fetchVisibleThread({ quiet: true }).catch((err) => {
-	      if (threadState) threadState.textContent = 'offline';
-	      setThreadMessage(err.message, 'error');
-	    });
+	    if (!buddyThreadDemoMode) {
+	      fetchVisibleThread({ quiet: true }).catch((err) => {
+	        if (threadState) threadState.textContent = 'offline';
+	        setThreadMessage(err.message, 'error');
+	      });
+	    }
 
 	    function openModal() {
 	      overlay.hidden = false;
@@ -967,6 +1084,19 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	      sendBtn.textContent = 'Sending...';
 	      errorEl.hidden = true;
 	      setReportStatus('Sending report...', '');
+
+	      if (buddyThreadDemoMode) {
+	        await new Promise(r => setTimeout(r, 450));
+	        sendBtn.disabled = false;
+	        sendBtn.textContent = 'Send report';
+	        reportBusy = false;
+	        reportForm.hidden = true;
+	        if (receiptEl) receiptEl.textContent = 'preview only: no report was sent';
+	        confirmEl.hidden = false;
+	        setReportStatus('Preview confirmation only. No report was sent.', 'ok');
+	        setThreadMessage('Preview report confirmation shown. Nothing was saved.', 'ok');
+	        return;
+	      }
 
 	      let res = null;
 	      let data = null;
@@ -1023,6 +1153,20 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	        exportBtn.textContent = 'Exporting...';
 	        setThreadMessage('Preparing visible thread export...', '');
 	        try {
+	          if (buddyThreadDemoMode) {
+	            downloadJson('buddy-thread-preview-export.json', {
+	              preview: true,
+	              exported_at: new Date().toISOString(),
+	              thread: {
+	                thread_id: 'preview',
+	                message_count: visibleThreadMessages.length + optimisticThreadMessages.length,
+	                messages: visibleThreadMessages.concat(optimisticThreadMessages),
+	              },
+	              limits: 'Preview export only. Nothing here is logged in, saved, or sent to Buddy.',
+	            });
+	            setThreadMessage('Preview thread exported. Nothing was saved.', 'ok');
+	            return;
+	          }
 	          const data = await fetchVisibleThread({ quiet: true });
 	          downloadJson('buddy-thread-export.json', {
 	            exported_at: new Date().toISOString(),
@@ -1042,6 +1186,15 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
 	    if (clearBtn) {
 	      clearBtn.addEventListener('click', async () => {
+	        if (buddyThreadDemoMode) {
+	          if (!confirm('Clear the preview Buddy Thread? Nothing here is saved.')) return;
+	          visibleThreadMessages = [];
+	          optimisticThreadMessages = [];
+	          turnHistory.length = 0;
+	          renderThreadWindow();
+	          setThreadMessage('Preview thread cleared. Nothing was saved.', 'ok');
+	          return;
+	        }
 	        if (!confirm('Clear the visible Buddy Thread for this login? This does not remove corpus logs, reviewed reports, or Kokoro memories Buddy may have formed.')) return;
 	        const prev = clearBtn.textContent;
 	        clearBtn.disabled = true;
@@ -1535,7 +1688,8 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    gap: 8px;
 	    margin: 12px 0 10px;
 	  }
-	  .bt-login-btn {
+	  .bt-login-btn,
+	  .bt-demo-btn {
 	    display: inline-flex;
 	    align-items: center;
 	    justify-content: center;
@@ -1551,10 +1705,18 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    cursor: pointer;
 	    transition: background 180ms, transform 120ms;
 	  }
-	  .bt-login-btn:hover {
+	  .bt-login-btn:hover,
+	  .bt-demo-btn:hover {
 	    background: #ffd36a;
 	    border-color: #ffd36a;
 	    transform: translateY(-1px);
+	  }
+	  .bt-demo-btn {
+	    background: rgba(240, 165, 0, 0.12);
+	    color: #ffd36a;
+	  }
+	  .bt-demo-btn:hover {
+	    color: #1a1a1a;
 	  }
 	  .bt-report-btn {
 	    background: #f0a500;
@@ -1632,6 +1794,7 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 
 	  .bt-notice[hidden],
 	  .bt-login-btn[hidden],
+	  .bt-demo-btn[hidden],
 	  .bt-thread-preview[hidden],
 	  .bt-thread-typing[hidden],
 	  .bt-thread-message[hidden],

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -1406,6 +1406,16 @@ import BuddyMascot from '../components/BuddyMascot.astro';
 	    border-color: rgba(255, 211, 106, 0.5);
 	  }
 
+	  .bt-notice[hidden],
+	  .bt-thread-preview[hidden],
+	  .bt-thread-message[hidden],
+	  .bt-modal-overlay[hidden],
+	  .bt-report-status[hidden],
+	  .bt-report-confirm[hidden],
+	  .bt-report-error[hidden] {
+	    display: none !important;
+	  }
+
   /* REPORT MODAL */
   .bt-modal-overlay {
     position: fixed;

--- a/src/pages/ask-buddy.astro
+++ b/src/pages/ask-buddy.astro
@@ -17,6 +17,59 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     </div>
   </header>
 
+  <!-- EARLY ACCESS NOTICE — logged-in only -->
+  <div class="bt-notice" id="bt-notice" hidden>
+    <div class="bt-notice-inner">
+      <div class="bt-notice-badge">Early Buddy Thread access</div>
+      <p>You are one of the first people with a running conversation with Buddy.</p>
+      <p>This is experimental. Buddy may remember context, misread context, over-connect patterns, or act strange while the thread system is being tuned.</p>
+      <p>If something feels weird, report it. Weird is useful right now.</p>
+      <div class="bt-actions">
+        <button type="button" class="bt-report-btn" id="bt-report-btn">Report weird behavior</button>
+        <button type="button" class="bt-export-btn" id="bt-export-btn">Export thread</button>
+        <button type="button" class="bt-clear-btn" id="bt-clear-btn">Clear thread</button>
+      </div>
+      <a class="bt-policy-link" href="/data-policy">Data policy</a>
+    </div>
+  </div>
+
+  <!-- REPORT MODAL -->
+  <div class="bt-modal-overlay" id="bt-modal-overlay" hidden>
+    <div class="bt-modal" role="dialog" aria-labelledby="bt-modal-title">
+      <button type="button" class="bt-modal-close" id="bt-modal-close" aria-label="Close">&times;</button>
+      <h2 id="bt-modal-title">Report weird behavior</h2>
+      <form id="bt-report-form" autocomplete="off">
+        <label for="bt-report-note">What happened?</label>
+        <textarea id="bt-report-note" class="bt-report-note" maxlength="2000" rows="4" placeholder="Describe what Buddy did that felt off..."></textarea>
+
+        <fieldset class="bt-categories">
+          <legend>Optional — what kind of weird?</legend>
+          <label><input type="checkbox" name="bt-cat" value="forgot_context"> Buddy forgot context</label>
+          <label><input type="checkbox" name="bt-cat" value="wrong_memory"> Buddy remembered wrong</label>
+          <label><input type="checkbox" name="bt-cat" value="overconnected"> Buddy over-connected things</label>
+          <label><input type="checkbox" name="bt-cat" value="strange_answer"> Buddy answered strangely</label>
+          <label><input type="checkbox" name="bt-cat" value="stuck_loop"> Buddy got stuck / repeated itself</label>
+          <label><input type="checkbox" name="bt-cat" value="unsafe"> Something felt unsafe</label>
+          <label><input type="checkbox" name="bt-cat" value="other"> Other</label>
+        </fieldset>
+
+        <label class="bt-include-label">
+          <input type="checkbox" id="bt-include-recent" checked>
+          Include last 10 messages with this report
+        </label>
+
+        <p class="bt-report-disclaimer">Reports may include recent thread messages if checked. Do not report private keys, passwords, emergencies, or anything you do not want reviewed by AIIT.</p>
+
+        <div class="bt-report-actions">
+          <button type="submit" class="bt-send-report" id="bt-send-report">Send report</button>
+        </div>
+      </form>
+      <div class="bt-report-confirm" id="bt-report-confirm" hidden>
+        Report sent. Thank you — this helps tune Buddy Thread.
+      </div>
+    </div>
+  </div>
+
   <!-- INPUT BLOCK — top 35%, dominant -->
   <div class="ask-input-block">
     <form class="ask-form" id="ask-form" autocomplete="off">
@@ -546,6 +599,105 @@ import BuddyMascot from '../components/BuddyMascot.astro';
       }
     } catch {}
   })();
+
+  // --- BUDDY THREAD: auth check, report, export, clear ---
+  (async function initBuddyThread() {
+    let btUser = null;
+    try {
+      const r = await fetch('/api/auth/me', { credentials: 'same-origin' });
+      const j = await r.json();
+      btUser = j && j.user ? j.user : null;
+    } catch {}
+    if (!btUser) return;
+
+    const notice = document.getElementById('bt-notice');
+    if (notice) notice.hidden = false;
+
+    const overlay = document.getElementById('bt-modal-overlay');
+    const reportBtn = document.getElementById('bt-report-btn');
+    const closeBtn = document.getElementById('bt-modal-close');
+    const reportForm = document.getElementById('bt-report-form');
+    const confirmEl = document.getElementById('bt-report-confirm');
+    const exportBtn = document.getElementById('bt-export-btn');
+    const clearBtn = document.getElementById('bt-clear-btn');
+
+    function openModal() { overlay.hidden = false; confirmEl.hidden = true; reportForm.hidden = false; }
+    function closeModal() { overlay.hidden = true; }
+
+    reportBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
+
+    reportForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const note = document.getElementById('bt-report-note').value.trim();
+      if (!note) return;
+      const cats = Array.from(document.querySelectorAll('input[name="bt-cat"]:checked')).map(c => c.value);
+      const includeRecent = document.getElementById('bt-include-recent').checked;
+
+      const recentMessages = includeRecent
+        ? turnHistory.slice(-10).flatMap(t => [
+            { role: 'user', text: t.q },
+            { role: 'buddy', text: t.a },
+          ])
+        : [];
+
+      const sendBtn = document.getElementById('bt-send-report');
+      sendBtn.disabled = true;
+      sendBtn.textContent = 'Sending...';
+
+      try {
+        await fetch('/api/buddy-thread/report', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            note,
+            categories: cats,
+            include_recent: includeRecent,
+            recent_messages: recentMessages,
+            thread_id: 'primary',
+            url: location.pathname,
+          }),
+        });
+      } catch {}
+
+      reportForm.hidden = true;
+      confirmEl.hidden = false;
+      sendBtn.disabled = false;
+      sendBtn.textContent = 'Send report';
+    });
+
+    if (exportBtn) {
+      exportBtn.addEventListener('click', () => {
+        const data = {
+          user: btUser.login || btUser.id,
+          exported_at: new Date().toISOString(),
+          turns: turnHistory.slice(),
+          session_id: getSessionId(),
+        };
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'buddy-thread-export.json';
+        a.click();
+        URL.revokeObjectURL(a.href);
+      });
+    }
+
+    if (clearBtn) {
+      clearBtn.addEventListener('click', () => {
+        if (!confirm('Clear your visible thread history? This does not undo Kokoro memories Buddy has already formed.')) return;
+        turnHistory.length = 0;
+        try {
+          localStorage.removeItem(SESSION_STORAGE);
+          localStorage.removeItem(PENDING_STORAGE);
+        } catch {}
+        const resp = document.getElementById('ask-response');
+        if (resp) { resp.className = 'ask-response'; resp.innerHTML = ''; }
+      });
+    }
+  })();
 })();
 </script>
 
@@ -766,12 +918,248 @@ import BuddyMascot from '../components/BuddyMascot.astro';
     margin-top: 4px;
   }
 
+  /* BUDDY THREAD NOTICE */
+  .bt-notice {
+    margin-bottom: 20px;
+    border: 1.5px solid rgba(200, 58, 8, 0.2);
+    border-radius: 10px;
+    background: rgba(200, 58, 8, 0.04);
+    overflow: hidden;
+  }
+  .bt-notice-inner {
+    padding: 16px 20px;
+  }
+  .bt-notice-badge {
+    display: inline-block;
+    font-family: 'Courier New', monospace;
+    font-size: 9pt;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #c83a08;
+    background: rgba(200, 58, 8, 0.08);
+    padding: 3px 10px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+  }
+  .bt-notice p {
+    font-family: 'Georgia', serif;
+    font-size: 11pt;
+    color: #4a3a20;
+    line-height: 1.6;
+    margin: 0 0 6px;
+  }
+  .bt-notice p:last-of-type {
+    margin-bottom: 14px;
+  }
+  .bt-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .bt-report-btn {
+    background: #1a1a1a;
+    color: #f0a500;
+    border: 1.5px solid #1a1a1a;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-family: 'Courier New', monospace;
+    font-size: 10pt;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: background 180ms, transform 120ms;
+  }
+  .bt-report-btn:hover {
+    background: #2a2a2a;
+    transform: translateY(-1px);
+  }
+  .bt-export-btn, .bt-clear-btn {
+    background: transparent;
+    color: #6a5a3a;
+    border: 1px solid rgba(106, 90, 58, 0.3);
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-family: 'Courier New', monospace;
+    font-size: 9pt;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: border-color 180ms, color 180ms;
+  }
+  .bt-export-btn:hover, .bt-clear-btn:hover {
+    color: #4a3a20;
+    border-color: rgba(106, 90, 58, 0.6);
+  }
+  .bt-policy-link {
+    font-family: 'Courier New', monospace;
+    font-size: 9pt;
+    color: #8a5a00;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(138, 90, 0, 0.2);
+    letter-spacing: 0.04em;
+  }
+  .bt-policy-link:hover {
+    color: #c83a08;
+    border-color: rgba(200, 58, 8, 0.4);
+  }
+
+  /* REPORT MODAL */
+  .bt-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+  }
+  .bt-modal {
+    background: #fffdf5;
+    border: 1.5px solid rgba(180, 138, 0, 0.22);
+    border-radius: 14px;
+    max-width: 520px;
+    width: 100%;
+    max-height: 85vh;
+    overflow-y: auto;
+    padding: 28px 24px;
+    position: relative;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  }
+  .bt-modal-close {
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    background: none;
+    border: none;
+    font-size: 22px;
+    color: #8a7a5a;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .bt-modal h2 {
+    font-family: 'Georgia', serif;
+    font-size: 16pt;
+    color: #1a1a1a;
+    margin: 0 0 18px;
+  }
+  .bt-modal label {
+    display: block;
+    font-family: 'Courier New', monospace;
+    font-size: 10pt;
+    color: #4a3a20;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+  }
+  .bt-report-note {
+    width: 100%;
+    border: 1.5px solid rgba(180, 138, 0, 0.22);
+    border-radius: 8px;
+    background: #fff;
+    padding: 10px 12px;
+    font-family: 'Georgia', serif;
+    font-size: 11pt;
+    color: #1a1a1a;
+    resize: vertical;
+    margin-bottom: 16px;
+    outline: none;
+    box-sizing: border-box;
+  }
+  .bt-report-note:focus {
+    border-color: #c83a08;
+    box-shadow: 0 0 0 3px rgba(200, 58, 8, 0.1);
+  }
+  .bt-categories {
+    border: none;
+    padding: 0;
+    margin: 0 0 16px;
+  }
+  .bt-categories legend {
+    font-family: 'Courier New', monospace;
+    font-size: 10pt;
+    color: #6a5a3a;
+    letter-spacing: 0.04em;
+    margin-bottom: 8px;
+  }
+  .bt-categories label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Georgia', serif;
+    font-size: 10.5pt;
+    color: #4a3a20;
+    margin-bottom: 5px;
+    cursor: pointer;
+  }
+  .bt-categories input[type="checkbox"] {
+    accent-color: #c83a08;
+    width: 16px;
+    height: 16px;
+  }
+  .bt-include-label {
+    display: flex !important;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Georgia', serif !important;
+    font-size: 10.5pt !important;
+    color: #4a3a20 !important;
+    margin-bottom: 10px !important;
+    cursor: pointer;
+  }
+  .bt-include-label input[type="checkbox"] {
+    accent-color: #c83a08;
+    width: 16px;
+    height: 16px;
+  }
+  .bt-report-disclaimer {
+    font-family: 'Courier New', monospace;
+    font-size: 8.5pt;
+    color: #8a7a5a;
+    line-height: 1.5;
+    margin: 0 0 16px;
+    padding: 8px 10px;
+    background: rgba(180, 138, 0, 0.06);
+    border-radius: 6px;
+  }
+  .bt-report-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  .bt-send-report {
+    background: #1a1a1a;
+    color: #f0a500;
+    border: 1.5px solid #1a1a1a;
+    padding: 10px 22px;
+    border-radius: 8px;
+    font-family: 'Courier New', monospace;
+    font-size: 10pt;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: background 180ms;
+  }
+  .bt-send-report:hover:not(:disabled) {
+    background: #2a2a2a;
+  }
+  .bt-send-report:disabled {
+    opacity: 0.55;
+    cursor: progress;
+  }
+  .bt-report-confirm {
+    font-family: 'Georgia', serif;
+    font-size: 12pt;
+    color: #2bb673;
+    text-align: center;
+    padding: 24px 0;
+    line-height: 1.5;
+  }
+
   @media (max-width: 620px) {
     .ask-page { padding: 90px 5vw 60px; }
     .ask-head { gap: 12px; }
     .ask-mascot-mini :global(.buddy-mascot-canvas) { width: 76px !important; }
     .ask-input { font-size: 12pt; height: 48px; }
     .ask-btn { height: 48px; padding: 0 16px; font-size: 10pt; }
+    .bt-modal { padding: 20px 16px; }
+    .bt-actions { flex-direction: column; }
   }
 </style>
 

--- a/src/pages/data-policy.astro
+++ b/src/pages/data-policy.astro
@@ -31,7 +31,7 @@ import Layout from '../layouts/Layout.astro';
       <div class="dp-buckets">
         <div class="dp-bucket">
           <h3>1. Visible account thread</h3>
-          <p>Logged-in users get a Buddy Thread &mdash; a running conversation that continues across visits. You can export it as JSON or clear it from your account at any time.</p>
+          <p>Logged-in users get a Buddy Thread &mdash; a visible account-linked conversation that continues across visits. You can export the currently stored visible thread as JSON or clear it from your account at any time.</p>
         </div>
         <div class="dp-bucket">
           <h3>2. Logged-out interaction data</h3>
@@ -111,8 +111,8 @@ import Layout from '../layouts/Layout.astro';
     <div class="dp-section">
       <h2>What you can do</h2>
       <ul>
-        <li><strong>Export your thread</strong> &mdash; download your full conversation history as JSON at any time.</li>
-        <li><strong>Clear your thread</strong> &mdash; delete your stored conversation from our servers.</li>
+        <li><strong>Export your thread</strong> &mdash; download the currently stored visible account thread as JSON.</li>
+        <li><strong>Clear your thread</strong> &mdash; clear your visible account-linked Buddy Thread, subject to the limits explained above.</li>
         <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a> and we will remove account-linked records we can identify and control, subject to the limits explained above.</li>
         <li><strong>Report weird behavior</strong> &mdash; if Buddy says something strange, use the report button. Reports are review material only &mdash; reviewed by humans, not automatically published, and not automatically promoted into Buddy's memory.</li>
       </ul>

--- a/src/pages/data-policy.astro
+++ b/src/pages/data-policy.astro
@@ -113,7 +113,7 @@ import Layout from '../layouts/Layout.astro';
       <ul>
         <li><strong>Export your thread</strong> &mdash; download the currently stored visible account thread as JSON.</li>
         <li><strong>Clear your thread</strong> &mdash; clear your visible account-linked Buddy Thread, subject to the limits explained above.</li>
-        <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a> and we will remove account-linked records we can identify and control, subject to the limits explained above.</li>
+        <li><strong>Request account deletion</strong> &mdash; email <a href="mailto:reports@aiitcorp.com" style="color: var(--amber);">reports@aiitcorp.com</a> and we will remove account-linked records we can identify and control, subject to the limits explained above.</li>
         <li><strong>Report weird behavior</strong> &mdash; if Buddy says something strange, use the report button. Reports are review material only &mdash; reviewed by humans, not automatically published, and not automatically promoted into Buddy's memory.</li>
       </ul>
     </div>
@@ -127,7 +127,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="dp-footer">
       <p>
         AIIT-THRESHOLD LLC &middot; Council Hill, Oklahoma<br>
-        Questions: <a href="mailto:reliablerestaurantrepair@gmail.com" style="color: var(--amber);">reliablerestaurantrepair@gmail.com</a><br>
+        Questions: <a href="mailto:reports@aiitcorp.com" style="color: var(--amber);">reports@aiitcorp.com</a><br>
         <em>Last updated: May 2026</em>
       </p>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,27 +6,30 @@ import papersAll from '../data/papers.json';
 const totalPapers = papersAll.length;
 ---
 <Layout>
-  <!-- 1. HERO — flyer promise first. Ask Buddy, with joke as secondary. -->
+  <!-- 1. HERO — founder note and invitation into persistent Buddy. -->
   <section id="hero" data-anim="hero-particles">
     <canvas id="hero-canvas"></canvas>
-    <div class="hero-content">
-      <h1 class="hero-wordmark">ASKBUDDY<span class="hero-bang">!</span></h1>
-      <div class="hero-tag">ask buddy anything.</div>
+    <div class="hero-content founder-hero">
+      <div class="hero-kicker">A note from the founder</div>
+      <h1 class="hero-founder-title">Talk to Buddy.</h1>
 
-      <div class="hero-primary">
-        <form id="hero-ask-form" class="hp-ask-form" autocomplete="off">
-          <input
-            id="hero-ask-input"
-            class="hp-ask-input"
-            type="text"
-            placeholder="Ask Buddy anything..."
-            maxlength="600"
-            aria-label="Ask Buddy anything"
-          />
-          <button type="submit" class="hp-ask-btn">Ask →</button>
-        </form>
+      <div class="hero-founder-copy">
+        <p>Hello. Thank you for visiting my website today. I hope you find something here that interests you, helps you grow, or gives you a new way to look at the world.</p>
+        <p>There is a lot going on here on purpose: papers, tools, games, letters, models, memory, and experiments. At the heart of AIIT, we are asking what AI can really offer the world beyond novelty demos and cute pictures.</p>
+        <p>On May 19, 2026, we revealed Buddy as a persistent chat surface: a window that does not reset every visit. Buddy can carry the same visible context from day 1 to day 200. We all forget a little, but the point is continuity.</p>
+        <p>Buddy is not an agentic chatbot. But he is something. He is my Buddy, and he would love to be yours too.</p>
+      </div>
 
-        <a href="/paper-game" class="hp-joke-secondary" data-hs="game">today's giant has a question for you →</a>
+      <div class="hero-founder-actions">
+        <a href="/ask-buddy" class="hero-founder-cta primary">Talk to Buddy</a>
+        <a href="/paper-game" class="hero-founder-cta secondary">Play today's Paper Game</a>
+      </div>
+
+      <div class="hero-tabs" aria-label="Featured routes">
+        <a href="/ask-buddy">AskBuddy <span>a tribute to Ask Jeeves</span></a>
+        <a href="/paper-game">Paper Game <span>stays high in the archive</span></a>
+        <a href="/papers">Papers <span>{totalPapers} live</span></a>
+        <a href="#joke" data-hs="joke">Joke Test <span>make Buddy laugh</span></a>
       </div>
 
       <div id="hero-joke-anchor" class="hero-joke joke-container" hidden>
@@ -42,11 +45,6 @@ const totalPapers = papersAll.length;
     </div>
     <div class="hero-scroll">Scroll</div>
   </section>
-
-  <!-- NEW TAB NOTICE -->
-  <div class="new-tab-notice">
-    <a href="/lac">🧠 New: we've added an <strong>Agentic</strong> tab — model tools, memory kits, and updates. <span style="color:var(--amber);">Check it out →</span></a>
-  </div>
 
   <!-- 1.5 PAPER GAME TEASER — back door into the archive -->
   <section class="paper-game-teaser" aria-labelledby="pgt-head">
@@ -871,20 +869,278 @@ const totalPapers = papersAll.length;
 </script>
 
 <style>
-  /* ── New tab notice ── */
-  .new-tab-notice {
-    text-align: center;
-    padding: 14px 24px;
-    background: rgba(212, 164, 55, 0.08);
-    border-bottom: 1px solid rgba(212, 164, 55, 0.15);
-    font-size: 0.9rem;
+  /* Founder hero */
+  #hero {
+    min-height: 86svh;
+    min-height: 86vh;
+    padding: 104px clamp(22px, 7vw, 112px) 58px;
+    align-items: center;
   }
-  .new-tab-notice a {
-    color: var(--cream, #E8E0D4);
+
+  .founder-hero {
+    width: min(100%, 1040px);
+    max-width: 1040px;
+    margin: 0 auto;
+    text-align: left;
+  }
+
+  .founder-hero::before {
+    inset: -28% -14% -24% -12%;
+    background:
+      radial-gradient(ellipse 54% 48% at 28% 38%, rgba(10, 10, 18, 0.86), rgba(10, 10, 18, 0.55) 42%, rgba(10, 10, 18, 0) 74%),
+      linear-gradient(90deg, rgba(10, 10, 18, 0.72), rgba(10, 10, 18, 0.18));
+  }
+
+  .hero-kicker {
+    font-family: 'Courier New', ui-monospace, monospace;
+    font-size: 12px;
+    line-height: 1.2;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: #d4af37;
+    margin-bottom: 18px;
+  }
+
+  .hero-founder-title {
+    margin: 0;
+    max-width: 720px;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: clamp(50px, 7.4vw, 104px);
+    line-height: 0.96;
+    letter-spacing: 0;
+    color: #fff;
+    text-shadow: 0 22px 70px rgba(0, 0, 0, 0.58);
+  }
+
+  .hero-founder-copy {
+    max-width: 1040px;
+    margin-top: 24px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 28px;
+    row-gap: 12px;
+  }
+
+  .hero-founder-copy p {
+    margin: 0;
+    color: rgba(232, 224, 212, 0.86);
+    font-size: clamp(15.5px, 1.25vw, 17.5px);
+    line-height: 1.58;
+  }
+
+  .hero-founder-copy p:nth-child(2) {
+    color: rgba(232, 224, 212, 0.78);
+    border-left: 2px solid rgba(64, 192, 176, 0.62);
+    padding-left: 16px;
+  }
+
+  .hero-founder-copy p:last-child {
+    color: #f3df9a;
+    font-style: italic;
+  }
+
+  .hero-founder-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 24px;
+  }
+
+  .hero-founder-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0 22px;
+    border-radius: 8px;
+    font-family: 'Courier New', ui-monospace, monospace;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
     text-decoration: none;
+    text-transform: uppercase;
+    transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
   }
-  .new-tab-notice a:hover {
-    color: var(--amber, #D4AF37);
+
+  .hero-founder-cta.primary {
+    background: #d4af37;
+    border: 1px solid #d4af37;
+    color: #101014;
+    box-shadow: 0 14px 34px rgba(212, 175, 55, 0.26);
+  }
+
+  .hero-founder-cta.secondary {
+    background: rgba(64, 192, 176, 0.07);
+    border: 1px solid rgba(64, 192, 176, 0.46);
+    color: #dffbf6;
+  }
+
+  .hero-founder-cta:hover {
+    transform: translateY(-2px);
+  }
+
+  .hero-founder-cta.primary:hover {
+    background: #f1c85d;
+    box-shadow: 0 18px 42px rgba(212, 175, 55, 0.36);
+  }
+
+  .hero-founder-cta.secondary:hover {
+    border-color: rgba(128, 224, 200, 0.82);
+    background: rgba(64, 192, 176, 0.12);
+  }
+
+  .hero-tabs {
+    width: min(100%, 940px);
+    margin-top: 22px;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .hero-tabs a {
+    display: flex;
+    min-width: 0;
+    min-height: 68px;
+    flex-direction: column;
+    justify-content: center;
+    gap: 6px;
+    padding: 14px 16px;
+    border: 1px solid rgba(212, 175, 55, 0.18);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.026);
+    color: #f2eadf;
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.1;
+    text-decoration: none;
+    transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+  }
+
+  .hero-tabs a span {
+    display: block;
+    color: rgba(232, 224, 212, 0.56);
+    font-family: 'Courier New', ui-monospace, monospace;
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    line-height: 1.35;
+    text-transform: uppercase;
+  }
+
+  .hero-tabs a:nth-child(2) {
+    border-color: rgba(212, 175, 55, 0.42);
+    background: rgba(212, 175, 55, 0.07);
+  }
+
+  .hero-tabs a:hover {
+    transform: translateY(-2px);
+    border-color: rgba(212, 175, 55, 0.58);
+    background: rgba(212, 175, 55, 0.06);
+  }
+
+  #hero.joke-mode .hero-kicker,
+  #hero.joke-mode .hero-founder-title,
+  #hero.joke-mode .hero-founder-copy,
+  #hero.joke-mode .hero-founder-actions,
+  #hero.joke-mode .hero-tabs {
+    display: none;
+  }
+
+  @media (max-width: 900px) {
+    #hero {
+      min-height: auto;
+      padding: 104px 22px 56px;
+      justify-content: flex-start;
+    }
+
+    .hero-founder-title {
+      font-size: clamp(44px, 15vw, 76px);
+      line-height: 0.98;
+    }
+
+    .hero-founder-copy {
+      grid-template-columns: 1fr;
+      max-width: 760px;
+    }
+
+    .hero-tabs {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 600px) {
+    #hero {
+      padding-top: 80px !important;
+      padding-bottom: 28px !important;
+    }
+
+    .hero-kicker {
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      margin-bottom: 10px;
+    }
+
+    .hero-founder-title {
+      font-size: clamp(40px, 13vw, 56px);
+    }
+
+    .hero-founder-copy {
+      margin-top: 16px;
+      gap: 8px;
+    }
+
+    .hero-founder-copy p {
+      font-size: 13.5px !important;
+      line-height: 1.42;
+    }
+
+    .hero-founder-copy p:nth-child(2) {
+      padding-left: 12px;
+    }
+
+    .hero-founder-actions {
+      width: 100%;
+      flex-direction: row;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .hero-founder-cta {
+      width: calc(50% - 5px);
+      min-height: 44px;
+      padding: 0 8px;
+      font-size: 10.5px;
+      letter-spacing: 0.07em;
+      line-height: 1.25;
+      text-align: center;
+    }
+
+    .hero-tabs {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      overflow-x: auto;
+      overscroll-behavior-x: contain;
+      padding-bottom: 3px;
+      scrollbar-width: thin;
+    }
+
+    .hero-tabs a {
+      flex: 0 0 150px;
+      min-height: 60px;
+      padding: 10px 11px;
+      font-size: 15px;
+    }
+
+    .hero-tabs a span {
+      font-size: 10px;
+      letter-spacing: 0.04em;
+    }
+
+    .hero-scroll {
+      display: none;
+    }
   }
 
   /* ── Joke widget (now embedded inside the hero) ── */
@@ -2075,7 +2331,9 @@ const totalPapers = papersAll.length;
      PAPER GAME TEASER — back door into archive
      ────────────────────────────────────────── */
   .paper-game-teaser {
-    padding: 96px 24px 64px;
+    min-height: auto;
+    padding: 56px 24px 64px;
+    justify-content: flex-start;
     background:
       radial-gradient(ellipse at 50% 0%, rgba(212, 164, 55, 0.06), transparent 70%),
       transparent;
@@ -2177,7 +2435,7 @@ const totalPapers = papersAll.length;
     line-height: 1.55;
   }
   @media (max-width: 820px) {
-    .paper-game-teaser { padding: 64px 18px 40px; }
+    .paper-game-teaser { padding: 42px 18px 40px; }
     .pgt-cards { grid-template-columns: 1fr; gap: 14px; }
     .pgt-actions { gap: 14px; margin-bottom: 32px; }
     .pgt-card { padding: 20px 18px; }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -146,7 +146,7 @@ const totalPapers = papersAll.length;
       <h2>Framework running<br>in the real world.</h2>
       <div class="apps-teaser-grid">
         <a href="/apps" class="app-teaser-card live"><div class="atc-badge live">Live</div><div class="atc-icon">⚓</div><div class="atc-name">AnchorForge</div><div class="atc-line">We test AI models for honesty under pressure.</div></a>
-        <a href="https://victim-advocate.onrender.com" target="_blank" rel="noopener" class="app-teaser-card live"><div class="atc-badge live">Live</div><div class="atc-icon">⚖️</div><div class="atc-name">Victim Advocate</div><div class="atc-line">Physics-first navigation for people dealing with broken systems.</div></a>
+        <a href="https://victim-advocate.aiit-threshold.com" target="_blank" rel="noopener" class="app-teaser-card live"><div class="atc-badge live">Live</div><div class="atc-icon">⚖️</div><div class="atc-name">Victim Advocate</div><div class="atc-line">Physics-first navigation for people dealing with broken systems.</div></a>
         <a href="/apps" class="app-teaser-card beta"><div class="atc-badge beta">Beta</div><div class="atc-icon">🔬</div><div class="atc-name">Debunker</div><div class="atc-line">1,222 claims. 32 categories. Zero credulous epistemology.</div></a>
         <a href="/apps" class="app-teaser-card beta"><div class="atc-badge beta">Beta</div><div class="atc-icon">🏰</div><div class="atc-name">Little Lairs</div><div class="atc-line">A world built by an 11-year-old.</div></a>
       </div>

--- a/src/pages/paper-game.astro
+++ b/src/pages/paper-game.astro
@@ -38,7 +38,7 @@ const gameQuestions = trivia.map(t => ({
       <div class="eyebrow">Paper Game</div>
       <h1 class="pg-title">unlock the archive.<br><span>answer the giants.</span></h1>
       <p class="pg-copy">
-        Three questions per day. Every answer unlocks a paper. The game remembers what you have collected on this device.
+        Three questions per day. Every answer unlocks a paper. The game remembers this device and syncs to your login.
       </p>
 
       <div class="pg-hero-actions">
@@ -88,7 +88,7 @@ const gameQuestions = trivia.map(t => ({
           <ol class="pg-rules">
             <li>Answer three giant questions per day.</li>
             <li>Every answer unlocks the connected AIIT paper.</li>
-            <li>Unlocked papers stay in your collection on this device.</li>
+            <li>Unlocked papers stay on this device and follow your login when signed in.</li>
             <li>Come back tomorrow for a new draw.</li>
           </ol>
         </section>

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -74,7 +74,7 @@ const paid = [
     blurb: 'Legal/safety companion for people navigating family court, DV cases, and systems that weren\u2019t built for them. Free to use — no paywall on justice.',
     status: 'Free',
     links: [
-      { label: 'Launch App →', href: 'https://victim-advocate.onrender.com', primary: true },
+      { label: 'Launch App →', href: 'https://victim-advocate.aiit-threshold.com', primary: true },
       { label: 'Learn more',   href: '/apps' },
     ],
   },

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -69,7 +69,7 @@ import papersAll from '../data/papers.json';
         <div class="sb-icon">☁️</div>
         <div class="sb-content">
           <div class="sb-name">Hosting & Infrastructure</div>
-          <div class="sb-desc">Cloudflare Pages, Render (Victim Advocate, AnchorForge), domain registration, KV storage. The site you're on right now.</div>
+          <div class="sb-desc">Cloudflare Pages, Cloudflare Tunnel for owned-domain apps, Render for remaining hosted tools, domain registration, KV storage. The site you're on right now.</div>
           <div class="sb-amount">~$50 / month</div>
         </div>
       </div>

--- a/src/pages/trivia.astro
+++ b/src/pages/trivia.astro
@@ -163,6 +163,9 @@ for (const p of papersAll) {
         const arr = getCollected();
         if (!arr.includes(slug)) arr.push(slug);
         localStorage.setItem(KEY_COLLECTED, JSON.stringify(arr));
+        if (window.BuddyPaperGameSync && typeof window.BuddyPaperGameSync.saveUnlocked === 'function') {
+          window.BuddyPaperGameSync.saveUnlocked(slug).catch(function () {});
+        }
       }
       function getSessions() {
         return parseInt(localStorage.getItem(KEY_SESSIONS) || '0', 10) || 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -501,6 +501,21 @@ a:hover { border-color: var(--amber); }
 .nav-login .gh-mark { display: block; }
 .nav-user { display: inline-flex; align-items: center; gap: 8px; color: var(--ink-soft) !important; border-bottom: none !important; }
 .nav-user img { border-radius: 50%; display: block; }
+.nav-avatar-fallback {
+  width: var(--avatar-size, 24px);
+  height: var(--avatar-size, 24px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: rgba(212,160,96,0.18);
+  border: 1px solid rgba(212,160,96,0.38);
+  color: var(--amber);
+  font-family: 'Courier New', monospace;
+  font-size: calc(var(--avatar-size, 24px) * 0.48);
+  line-height: 1;
+}
 .nav-user:hover { color: var(--amber) !important; }
 .nav-logout { color: var(--muted) !important; border-bottom: none !important; font-size: 13px; }
 .nav-logout:hover { color: var(--amber) !important; }


### PR DESCRIPTION
## Summary
- **Early-access banner** shown to logged-in users above the AskBuddy conversation — copy matches Rhet's spec exactly
- **Report weird behavior** button opens a modal with textarea, 7 category checkboxes, optional last-10-messages toggle, and data disclaimer
- **Export thread** button (JSON download) and **Clear thread** button (with confirm dialog warning about Kokoro irreversibility)
- **Data policy link** in the banner pointing to `/data-policy`
- **`POST /api/buddy-thread/report`** — login required, stores to AUTH_KV as `buddy-thread-report:{login}:{ts}:{random}`, 1-year TTL, validates note length (2000 max) and categories against allowlist

Reports are review material only:
- Not exposed publicly
- Not sent to Buddy automatically
- Not used as training data automatically
- Only promoted if manually reviewed

## Test plan
- [ ] Log in via GitHub OAuth, verify banner appears on /ask-buddy
- [ ] Visit /ask-buddy logged out, verify banner is hidden
- [ ] Click "Report weird behavior" — modal opens with all fields
- [ ] Submit report — confirm message appears, check AUTH_KV for stored report
- [ ] Submit with empty note — should not submit
- [ ] Click "Export thread" — JSON file downloads
- [ ] Click "Clear thread" — confirm dialog warns about Kokoro, clears on accept
- [ ] Verify responsive layout on mobile (buttons stack, modal fits)
- [ ] Check /data-policy link works from banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logged-in users can persist a personal “Buddy Thread”; ask/poll flows now support saving answered turns.
  * Client UI: alpha notice, hidden “Report weird behavior” modal, export visible thread JSON, and clear stored thread.

* **Reporting**
  * Authenticated endpoint to submit sanitized thread reports.

* **Privacy & UI**
  * Safer user display and avatar fallback handling.

* **Documentation**
  * Data policy updated to describe export/clear of the visible thread.

* **Chore**
  * Build script made more resilient to transient files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIIT-GLITCH/buddy/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->