### PR TITLE
Document deployment runbooks and add build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prepare CI paper source directory
+        run: mkdir -p /home/buddy_ai/Desktop/PRINT_READY
+
       - name: Build
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: Prepare CI paper source directory
-        run: mkdir -p /home/buddy_ai/Desktop/PRINT_READY
+        run: sudo install -d -o "$USER" -g "$USER" /home/buddy_ai/Desktop/PRINT_READY
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,133 @@
+# AIIT Site / Buddy Web Surface
+
+This repository is the public AIIT/Buddy web surface. It is an Astro site with
+Cloudflare Pages Functions for interactive endpoints such as Ask Buddy, joke,
+paper browsing, downloads, and public demos.
+
+It is not the full local Buddy runtime, not the model weights, and not the
+Kokoro memory store. The web surface routes into the canonical Buddy/Lil Homie
+backend and memory systems.
+
+## Start Here
+
+Read these files before changing Buddy-facing behavior:
+
+- `BUDDY_KOKORO_MEMORY.md` - why stateless web surfaces caused identity drift.
+- `MEMORY_ARCHITECTURE.md` - Buddy Kokoro memory versus Lil Homie experiential
+  memory.
+- `INGESTION_GATE.md` - required route pattern for public Buddy/Lil Homie
+  responses.
+- `DEV_ARCHITECTURE.md` - surface versus substrate architecture and response
+  shape.
+- `PAPERS_SCHEMA.md` - paper/catalog structure.
+
+Core identity rule:
+
+```text
+Rhet Wike built Buddy.
+AIIT-THRESHOLD is the house, site, and system context.
+It is not the builder.
+```
+
+If a Buddy web surface answers otherwise, the surface is broken.
+
+## What This Repo Contains
+
+```text
+src/                  Astro pages and UI components
+functions/api/        Cloudflare Pages API routes
+functions/_lib/       Shared route helpers, including ingestion bridge
+public/               Static assets, downloads, papers, flyers, icons
+docs/                 Deployment, environment, API, and incident docs
+scripts/              Build guards, paper index generation, version stamping
+transcripts/          Captured agent/session transcripts with checksums
+```
+
+Important public Buddy routes:
+
+- `functions/api/askbuddy.js`
+- `functions/api/askbuddy_poll.js`
+- `functions/api/joke.js`
+- `functions/_lib/ingest.js`
+
+Any route that returns a Buddy or Lil Homie answer must use the ingestion
+bridge. Do not add a direct model call or a stateless prompt fallback for a
+Buddy surface.
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+Build:
+
+```bash
+npm run build
+```
+
+The build runs route guards and paper indexing before `astro build`.
+
+Useful scripts:
+
+```bash
+npm run guard:buddy
+npm run index
+npm run preview
+```
+
+## Deployment
+
+This is an Astro project intended for Cloudflare Pages.
+
+- Build command: `npm run build`
+- Output directory: `dist`
+- Production branch: `master`
+- Production domain: `https://aiit-threshold.com`
+
+Deployment docs live in:
+
+- `docs/DEPLOYMENT.md`
+- `docs/ENVIRONMENT.md`
+- `docs/API_SURFACES.md`
+- `docs/INCIDENT_RUNBOOK.md`
+- `docs/PREVIEW_AUTH_SETUP.md`
+- `docs/SNAPPY_NAV_STANDARD.md`
+
+Cloudflare dashboard bindings and secrets are required for runtime behavior.
+The static build can pass while AskBuddy, OAuth, Stripe, Gary, or Paper Game
+features fail at runtime if dashboard configuration is missing.
+
+Never commit `.env`, secret values, Cloudflare Access tokens, Stripe secrets,
+GitHub tokens, local logs, `dist/`, or `node_modules/`.
+
+## Identity And Memory Rules
+
+Buddy identity is not defined by this website. The site must preserve and route
+to the canonical memory layer.
+
+Load order must remain:
+
+```text
+1. Kokoro identity/cognition
+2. Lil Homie experience
+3. Current session input
+```
+
+The historical failure mode documented in `BUDDY_KOKORO_MEMORY.md` was a
+stateless Cloudflare surface acting like Buddy without loading the identity
+surface. Future changes must not recreate that failure mode.
+
+## For Agents
+
+Before modifying any Buddy-facing endpoint:
+
+1. Read `BUDDY_KOKORO_MEMORY.md`.
+2. Read `INGESTION_GATE.md`.
+3. Inspect the current route implementation.
+4. Preserve the ingestion bridge.
+5. Do not create direct model fallbacks for Buddy identity or Buddy responses.
+
+This repo is a public surface for a memory-backed system, and the routing layer
+is part of the identity safety boundary.

--- a/docs/API_SURFACES.md
+++ b/docs/API_SURFACES.md
@@ -1,0 +1,188 @@
+# API Surfaces
+
+This inventory covers Cloudflare Pages Functions under `functions/api/`.
+Shared helpers under `functions/_lib/` are not routes.
+
+## Summary
+
+| Route | Method | Auth Model | KV/Storage | Rate Limit | Failure Mode |
+| --- | --- | --- | --- | --- | --- |
+| `/api/askbuddy` | `POST`, `OPTIONS` | Public route with origin/referrer allowlist; optional dev bypass | `ASKBUDDY_USAGE` or `JOKE_KV` for throttle/logs; `AUTH_KV` for logged-in thread | 4/min per IP/fingerprint and 24/min global when KV exists | JSON error, usually 200 with offline/pressure message or 403 for origin |
+| `/api/askbuddy_poll` | `POST`, `OPTIONS` | Public route with origin/referrer allowlist | `AUTH_KV` for logged-in thread persistence | Backend queue pressure only | JSON pending/ready/error frame |
+| `/api/joke` | `POST`, `OPTIONS` | Public route with origin/referrer check; optional dev bypass | `JOKE_KV` for throttle | 10/min per visitor when `JOKE_KV` exists | JSON error or offline message |
+| `/api/auth/github/login` | `GET` | Public OAuth start | `AUTH_KV` stores OAuth state when bound | None | Redirect to GitHub or 500 missing client id |
+| `/api/auth/github/callback` | `GET` | GitHub OAuth callback | `AUTH_KV` stores sessions and consumed state | GitHub OAuth controls | 400/502 text response or login retry redirect |
+| `/api/auth/me` | `GET` | Session cookie optional | `AUTH_KV` reads session and pro status | None | JSON `{ "user": null }` and expired cookie cleanup |
+| `/api/auth/logout` | `GET`, `POST` | Session cookie optional | `AUTH_KV` deletes session | None | Redirect or JSON `{ "ok": true }` |
+| `/api/buddy-thread/thread` | `GET`, `DELETE`, `OPTIONS` | Requires `aiit_session` login | `AUTH_KV` reads/clears user-visible Buddy thread | None | JSON `login_required`, `auth_kv_missing`, or operation error |
+| `/api/buddy-thread/report` | `POST`, `OPTIONS` | Requires `aiit_session` login | `AUTH_KV` stores report; optional email providers notify | None | JSON report write/mail status |
+| `/api/paper-game/collection` | `GET`, `POST` | GET returns anonymous state if logged out; POST requires login and same-origin | `AUTH_KV` stores collected slugs | None | JSON `login_required`, `auth_kv_missing`, or validation error |
+| `/api/leaderboard/flap` | `GET`, `POST` | Public | `AUTH_KV` stores top scores | None | JSON error for bad score/json; empty list if KV missing |
+| `/api/gary-memory` | `POST`, `OPTIONS` | Requires logged-in GitHub user via `/api/auth/me` | `GARY_MEMORY` stores per-user Gary memory | Size/count caps only | JSON `gary-memory not configured`, `not logged in`, or corrupt record |
+| `/api/gary-write` | `POST`, `OPTIONS` | Requires same-site origin, logged-in owner, `OWNER_LOGIN` match | GitHub Contents API writes repo; signed write cookie | 15 writes/day via signed cookie | JSON auth/config/path/GitHub errors |
+| `/api/broke-gary` | `POST`, `OPTIONS` | Public origin check plus signed free-call cookie | Signed cookie only; Anthropic API upstream | 3 free calls per cookie | JSON config/gate errors or upstream Anthropic response |
+| `/api/browse` | `POST`, `OPTIONS` | Public origin/referrer check | No persistence | Timeout and 30k char response cap | JSON validation/upstream/fetch error |
+| `/api/anchorforge/gate` | `POST` | Requires `aiit_session` login | `ANCHORFORGE_KV` for usage; GitHub repo write for logs | 1/week free, 1/day pro when KV exists | JSON login/rate/config/GitHub/model errors |
+| `/api/download` | `GET` | Requires valid paid Stripe Checkout session id | Fetches allowed public zip assets | Stripe API limits | Text 400/403/404 or file download |
+| `/api/verify-purchase` | `GET` | Requires valid Stripe Checkout session id | Stripe API only | Stripe API limits | Redirects to product or success page |
+| `/api/stripe/webhook` | `POST` | Stripe signature verification | `AUTH_KV` writes/clears pro records; email notification attempt | Stripe retry policy | Text 400/500 or JSON received |
+
+## Data Retention Notes
+
+- AskBuddy stores short throttle counters and short-lived logs in
+  `ASKBUDDY_USAGE` or `JOKE_KV` when bound. Logged-in thread turns are stored in
+  `AUTH_KV`.
+- Buddy thread reports are stored in `AUTH_KV` for review and may include the
+  reporter note and selected recent messages.
+- Paper Game collection stores normalized paper slugs in `AUTH_KV`.
+- Gary memory stores per-user messages, notes, exit state, and counters in
+  `GARY_MEMORY`.
+- Stripe webhook stores pro/subscription state in `AUTH_KV`; Stripe remains the
+  payment source of truth.
+- AnchorForge writes submitted raw output and verdict markdown to the configured
+  GitHub log repo.
+
+## Endpoint Details
+
+### `/api/askbuddy`
+
+- Route file: `functions/api/askbuddy.js`
+- Method: `POST`, `OPTIONS`
+- Auth required: No. Logged-in users get account thread persistence.
+- KV used: `ASKBUDDY_USAGE` or `JOKE_KV` for throttle/logs; `AUTH_KV` for
+  account thread lookup and storage.
+- Data stored: throttle counters, short question log snippets, account thread
+  messages for logged-in users.
+- Rate limit: 4 requests/minute per IP/fingerprint and 24 requests/minute
+  global when KV exists.
+- Failure mode: fail-closed if Buddy backend is not configured, offline, or does
+  not confirm `corpus_written:true`.
+- User-visible behavior: JSON with `ok:false` and pressure/offline message.
+
+### `/api/askbuddy_poll`
+
+- Route file: `functions/api/askbuddy_poll.js`
+- Method: `POST`, `OPTIONS`
+- Auth required: No. Logged-in users can save ready answers to account thread.
+- KV used: `AUTH_KV` for logged-in thread persistence.
+- Data stored: completed thread turn for logged-in users.
+- Rate limit: no edge throttle in this route; Buddy backend queue controls apply.
+- Failure mode: returns pending, ready, or JSON error based on Buddy poll result.
+- User-visible behavior: JSON status frame.
+
+### `/api/joke`
+
+- Route file: `functions/api/joke.js`
+- Method: `POST`, `OPTIONS`
+- Auth required: No.
+- KV used: `JOKE_KV` for throttle.
+- Data stored: throttle counters only in this route.
+- Rate limit: 10 requests/minute per visitor when `JOKE_KV` exists.
+- Failure mode: fail-closed through Buddy ingestion helper.
+- User-visible behavior: JSON reaction or error/offline message.
+
+### Auth Routes
+
+- Route files:
+  - `functions/api/auth/github/login.js`
+  - `functions/api/auth/github/callback.js`
+  - `functions/api/auth/me.js`
+  - `functions/api/auth/logout.js`
+- Methods: login/callback/me use `GET`; logout uses `GET` and `POST`.
+- Auth required: GitHub OAuth for session creation; session cookie for user
+  lookup/logout.
+- KV used: `AUTH_KV`.
+- Data stored: OAuth state, session records, pro lookup.
+- Rate limit: none in repo.
+- Failure mode: missing env/KV causes login failure or anonymous session result.
+- User-visible behavior: redirects, plain text OAuth errors, or JSON user state.
+
+### Buddy Thread Routes
+
+- Route files:
+  - `functions/api/buddy-thread/thread.js`
+  - `functions/api/buddy-thread/report.js`
+- Methods: thread uses `GET`, `DELETE`, `OPTIONS`; report uses `POST`,
+  `OPTIONS`.
+- Auth required: logged-in GitHub session.
+- KV used: `AUTH_KV`.
+- Data stored: visible Buddy thread record; user-submitted report records.
+- Rate limit: none in repo.
+- Failure mode: JSON `login_required`, `auth_kv_missing`, write failure, or mail
+  delivery failure.
+- User-visible behavior: JSON thread/report status.
+
+### `/api/paper-game/collection`
+
+- Route file: `functions/api/paper-game/collection.js`
+- Method: `GET`, `POST`
+- Auth required: GET works logged out; POST requires login and same-origin.
+- KV used: `AUTH_KV`.
+- Data stored: per-user collected paper slugs and update timestamp.
+- Rate limit: none in repo.
+- Failure mode: JSON `login_required`, `auth_kv_missing`, invalid JSON, or
+  forbidden origin.
+- User-visible behavior: sync succeeds or collection remains local/unsynced.
+
+### `/api/leaderboard/flap`
+
+- Route file: `functions/api/leaderboard/flap.js`
+- Method: `GET`, `POST`
+- Auth required: No.
+- KV used: `AUTH_KV`.
+- Data stored: top 25 score records with name, score, timestamp.
+- Rate limit: none in repo.
+- Failure mode: bad JSON/score returns 400; missing KV returns empty board and
+  drops writes.
+- User-visible behavior: leaderboard JSON.
+
+### Gary Routes
+
+- Route files:
+  - `functions/api/gary-memory.js`
+  - `functions/api/gary-write.js`
+  - `functions/api/broke-gary.js`
+  - `functions/api/browse.js`
+- Auth required:
+  - Gary memory requires logged-in user.
+  - Gary write requires logged-in owner matching `OWNER_LOGIN`.
+  - Broke Gary is public after origin check and signed cookie gate.
+  - Browse is public after origin/referrer check.
+- KV/storage used:
+  - `GARY_MEMORY` for Gary memory.
+  - GitHub Contents API for Gary write.
+  - signed cookies for free-call/write counters.
+  - no persistence for browse.
+- Rate limit:
+  - Gary write: 15 writes/day by signed cookie.
+  - Broke Gary: 3 calls per signed cookie.
+  - Browse: timeout and response-size caps.
+- Failure mode: JSON auth/config/upstream/path errors.
+- User-visible behavior: JSON status or upstream model response.
+
+### `/api/anchorforge/gate`
+
+- Route file: `functions/api/anchorforge/gate.js`
+- Method: `POST`
+- Auth required: logged-in GitHub session.
+- KV used: `ANCHORFORGE_KV` for usage limit; `AUTH_KV` for session/pro lookup.
+- Data stored: usage marker in KV; markdown log in GitHub log repo.
+- Rate limit: 1/week free and 1/day pro when `ANCHORFORGE_KV` exists.
+- Failure mode: JSON login, rate, config, GitHub, or model error.
+- User-visible behavior: JSON result with commit URL on success.
+
+### Commerce Routes
+
+- Route files:
+  - `functions/api/download.js`
+  - `functions/api/verify-purchase.js`
+  - `functions/api/stripe/webhook.js`
+- Methods: download/verify use `GET`; webhook uses `POST`.
+- Auth required: Stripe Checkout session for download/verify; Stripe signature
+  for webhook.
+- KV/storage used: webhook writes pro records to `AUTH_KV`.
+- Data stored: pro/subscription status, customer/subscription ids.
+- Rate limit: Stripe retry/API limits.
+- Failure mode: invalid session, unpaid session, missing file, invalid webhook
+  signature, missing webhook secret.
+- User-visible behavior: file download, redirect, or webhook status.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,158 @@
+# Deployment
+
+This repo is the public AIIT/Buddy web surface. It is intended to deploy on
+Cloudflare Pages as a static Astro site with Cloudflare Pages Functions.
+
+## Cloudflare Pages Target
+
+- Cloudflare Pages project: `buddy-bb4`
+- Production domain: `https://aiit-threshold.com`
+- Production branch: `master`
+- Build command: `npm run build`
+- Output directory: `dist`
+- Runtime: Cloudflare Pages static hosting plus Pages Functions under
+  `functions/`
+
+The Cloudflare dashboard must provide the environment variables and KV bindings
+documented in `docs/ENVIRONMENT.md`. The repo does not contain secret values.
+
+## Required Runtime Configuration
+
+Required KV bindings for normal production behavior:
+
+- `AUTH_KV`
+- `ASKBUDDY_USAGE` or `JOKE_KV`
+- `GARY_MEMORY` if Gary memory is enabled
+- `ANCHORFORGE_KV` if AnchorForge rate limits are enabled
+
+Required secrets/env vars for core public behavior:
+
+- `BUDDY_BACKEND_URL`
+- `BUDDY_CF_ACCESS_CLIENT_ID`
+- `BUDDY_CF_ACCESS_CLIENT_SECRET`
+- `BUDDY_BACKEND_TOKEN` when required by the Buddy backend
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+
+Required secrets/env vars for optional paid or tool surfaces:
+
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `ANTHROPIC_API_KEY`
+- `BROKE_GARY_SECRET`
+- `GITHUB_PAT`
+- `GITHUB_WRITE_TOKEN`
+- `OWNER_LOGIN`
+
+See `docs/ENVIRONMENT.md` for purpose, preview requirements, and missing-value
+symptoms for each item.
+
+## Local Build
+
+```bash
+npm ci
+npm run build
+```
+
+`npm run build` runs the Buddy route guard, rebuilds the paper index, runs
+Astro, injects paper-game sync assets, and writes the version stamp.
+
+## Expected Cloudflare Behavior
+
+Cloudflare Pages should:
+
+- install dependencies from `package-lock.json`
+- run `npm run build`
+- publish `dist/`
+- serve static assets through Cloudflare CDN
+- serve API routes from `functions/api/`
+- apply cache and redirect rules from `public/_headers` and `public/_redirects`
+
+Cloudflare Pages does not rebuild or repair dashboard configuration. Missing
+KV bindings, OAuth secrets, Stripe secrets, or Buddy backend access credentials
+will produce runtime failures after a successful static build.
+
+## Preview Deploys
+
+Preview deploys are expected for pull requests and non-production branches if
+the Cloudflare Pages GitHub integration is enabled.
+
+Preview auth requires separate preview values for:
+
+- `GITHUB_CLIENT_ID`
+- `GITHUB_CLIENT_SECRET`
+- `AUTH_KV`
+
+See `docs/PREVIEW_AUTH_SETUP.md` for the preview OAuth callback and setup
+notes. Preview and production dashboard settings are separate.
+
+## Production Deploys
+
+Production deploys are expected from `master`.
+
+Before merging to `master`:
+
+```bash
+npm ci
+npm run build
+git diff --check
+```
+
+After merge, confirm the Cloudflare Pages deployment completed and that the
+commit SHA in Cloudflare matches the merged commit.
+
+## Post-Deploy Smoke Checks
+
+Use a browser for page checks and `curl` for API checks. Do not include secrets
+in terminal history.
+
+```bash
+curl -I https://aiit-threshold.com/
+curl -I https://aiit-threshold.com/ask-buddy/
+curl -I https://aiit-threshold.com/paper-game/
+curl -I https://aiit-threshold.com/agentic/
+curl -I https://aiit-threshold.com/data-policy/
+curl -s https://aiit-threshold.com/api/auth/me
+curl -s https://aiit-threshold.com/api/leaderboard/flap
+```
+
+Expected results:
+
+- `/` returns 200.
+- `/ask-buddy/` returns 200 and the UI loads without console boot errors.
+- `/paper-game/` returns 200 and does not show sync/auth errors before login.
+- `/agentic/` returns 200 and media assets load.
+- `/data-policy/` returns 200.
+- `/api/auth/me` returns JSON, normally `{"user":null}` when logged out.
+- `/api/leaderboard/flap` returns JSON with a `scores` array.
+
+For AskBuddy behavior, use the site UI after verifying the Buddy backend is
+healthy. Avoid load testing the public route from a shell.
+
+## Rollback
+
+Preferred rollback:
+
+1. Open Cloudflare Pages project `buddy-bb4`.
+2. Go to Deployments.
+3. Select the last known-good production deployment.
+4. Use Cloudflare Pages rollback/promote controls to restore it.
+5. Run the smoke checks above.
+
+Git rollback:
+
+```bash
+git revert <bad-commit-sha>
+git push origin master
+```
+
+Only use git rollback when the problem is in committed source. If the problem
+is a dashboard secret, KV binding, OAuth callback, or Cloudflare Access policy,
+fix the dashboard setting instead of reverting source.
+
+What not to do during rollback:
+
+- Do not edit Buddy runtime or tunnel wiring from this repo.
+- Do not paste secrets into commits, issues, prompts, or logs.
+- Do not disable the Buddy ingestion gate to make a page look healthy.
+- Do not replace a failing Buddy route with a direct model fallback.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -57,6 +57,12 @@ npm run build
 `npm run build` runs the Buddy route guard, rebuilds the paper index, runs
 Astro, injects paper-game sync assets, and writes the version stamp.
 
+The paper index script currently expects a build-time source directory at
+`/home/buddy_ai/Desktop/PRINT_READY`. Cloudflare Pages currently has enough
+project context for its deploy to pass. GitHub Actions creates an empty
+placeholder directory before `npm run build` so the CI job verifies the site
+build path without committing private/local paper source files.
+
 ## Expected Cloudflare Behavior
 
 Cloudflare Pages should:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,81 @@
+# Environment Inventory
+
+This file lists Cloudflare Pages bindings and secrets by name only. Do not
+commit values. Configure values in Cloudflare Pages dashboard for project
+`buddy-bb4`.
+
+Production and preview have separate environment settings. A variable present
+in production is not automatically present in preview.
+
+## Core Bindings And Secrets
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `AUTH_KV` | GitHub OAuth sessions, pro status, Buddy thread records, reports, paper-game collection, leaderboard fallback storage | Required for account features | Required for preview auth/account testing | Login loops, `auth_kv_missing`, paper-game sync fails, thread export fails |
+| `JOKE_KV` | Joke route per-minute throttle; fallback AskBuddy throttle/log KV when `ASKBUDDY_USAGE` is absent | Recommended | Optional | Joke route still works if Buddy is configured, but edge throttling/logging is reduced |
+| `ASKBUDDY_USAGE` | AskBuddy per-client and global throttle plus short-lived usage logs | Recommended | Optional | AskBuddy can run without edge throttle if no fallback KV exists |
+| `BUDDY_BACKEND_URL` | Cloudflare Tunnel/Access URL for Buddy backend | Required for AskBuddy/Joke | Required for preview AskBuddy/Joke | `buddy_not_configured` or "buddy backend missing" |
+| `BUDDY_CF_ACCESS_CLIENT_ID` | Cloudflare Access service token client id for Buddy backend | Required for AskBuddy/Joke | Required for preview AskBuddy/Joke | Buddy backend rejects or route returns not configured |
+| `BUDDY_CF_ACCESS_CLIENT_SECRET` | Cloudflare Access service token client secret for Buddy backend | Required for AskBuddy/Joke | Required for preview AskBuddy/Joke | Buddy backend rejects or route returns not configured |
+| `BUDDY_BACKEND_TOKEN` | Optional backend bearer token when Buddy requires a second auth check | Depends on backend policy | Depends on backend policy | Buddy may return auth failure even when Cloudflare Access succeeds |
+| `BUDDY_WEB_ASK_TOKEN` | Legacy Buddy web ask token name, not read by current source | No, unless legacy backend still expects it outside this repo | No | No current repo symptom; document external use before relying on it |
+| `DEV_BYPASS` | Optional admin bypass for AskBuddy/Joke route throttles | Optional | Optional | Admin bypass header/body token has no effect |
+
+## GitHub OAuth
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `GITHUB_CLIENT_ID` | GitHub OAuth app client id | Required for login | Required for preview login | `/api/auth/github/login` returns OAuth not configured |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret | Required for login callback | Required for preview login callback | Callback token exchange fails |
+
+Preview OAuth callback setup is documented in `docs/PREVIEW_AUTH_SETUP.md`.
+
+## Commerce And Stripe
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `STRIPE_SECRET_KEY` | Verifies Checkout sessions for download and purchase success routes | Required for paid flows | Optional unless testing paid flows | Download/verify purchase routes reject or redirect |
+| `STRIPE_WEBHOOK_SECRET` | Verifies Stripe webhook signatures | Required for webhook | Optional unless testing webhook | Webhook returns `webhook secret not configured` |
+| `NOTIFY_FROM` | Sender address for payment/report notifications | Optional | Optional | Defaults to source-defined sender address |
+
+## Gary And AnchorForge
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `ANTHROPIC_API_KEY` | Gary free-call bridge and AnchorForge adjudication model access | Required for those routes | Optional unless testing those routes | `broke-gary not configured` or AnchorForge server misconfigured |
+| `BROKE_GARY_SECRET` | HMAC secret for Gary free-call and Gary write cookies | Required for Gary free-call/write routes | Optional unless testing those routes | Gary gate/write routes return not configured |
+| `GARY_MEMORY` | KV namespace for per-user Gary memory | Required for Gary memory | Optional unless testing Gary memory | `gary-memory not configured` |
+| `GITHUB_PAT` | Fine-grained GitHub token for `/api/gary-write` repository writes | Required for Gary write | Usually disabled in preview | `gary-write not configured` |
+| `OWNER_LOGIN` | GitHub login allowed to use `/api/gary-write` | Required for Gary write | Usually disabled in preview | `auth not configured` or owner-only rejection |
+| `GITHUB_WRITE_TOKEN` | GitHub token used by AnchorForge to write site-gated logs | Required for AnchorForge gate | Optional unless testing AnchorForge | AnchorForge returns `server_misconfigured` |
+| `ANCHORFORGE_KV` | KV namespace for AnchorForge rate limits | Recommended | Optional | AnchorForge still runs but per-period rate limiting is not enforced |
+
+## Reports And Email
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `REPORTS_TO` | Comma-separated Buddy report recipients | Optional | Optional | Uses source default recipient |
+| `REPORTS_FROM` | Sender address for Buddy reports | Optional | Optional | Uses `NOTIFY_FROM` or source default |
+| `REPORTS_DELIVERY_TO` | Verified destination for report mailer service binding | Optional | Optional | Uses source default |
+| `REPORT_MAILER` | Cloudflare service binding to internal report mailer Worker | Optional | Optional | Falls back to other email methods or reports stored without mail delivery |
+| `CF_EMAIL_API_TOKEN` | Cloudflare Email Sending token | Optional | Optional | Cloudflare email fallback unavailable |
+| `CLOUDFLARE_EMAIL_API_TOKEN` | Alternate Cloudflare Email Sending token name | Optional | Optional | Cloudflare email fallback unavailable |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account id for Email Sending | Optional | Optional | Uses source default if present |
+| `MAILCHANNELS_API_KEY` | MailChannels Email API key for Buddy reports | Optional | Optional | MailChannels report delivery unavailable |
+
+## Lil Homie Legacy Bridge
+
+| Name | Purpose | Production | Preview | Missing Symptom |
+| --- | --- | --- | --- | --- |
+| `LIL_HOMIE_URL` | Optional override for Lil Homie backend URL in the shared ingestion helper | Legacy/conditional | Legacy/conditional | Only affects routes intentionally using `callLilHomie` |
+| `LIL_HOMIE_TOKEN` | Bearer token for Lil Homie ingestion helper | Legacy/conditional | Legacy/conditional | `lilhomie_not_configured` for routes intentionally using `callLilHomie` |
+
+Current guarded Buddy surfaces should route through `callBuddy`, not direct
+Lil Homie calls.
+
+## Text/SMS Alert Lane
+
+No `TEXTNOW_*` or equivalent alert-lane secrets are referenced by this repo at
+the time of this inventory. If the alert lane is configured outside this repo,
+document the exact variable names and owner in this file before treating it as
+rebuildable.

--- a/docs/INCIDENT_RUNBOOK.md
+++ b/docs/INCIDENT_RUNBOOK.md
@@ -1,0 +1,323 @@
+# Incident Runbook
+
+This runbook covers the public AIIT site, Cloudflare Pages Functions, and the
+Cloudflare dashboard configuration required by this repo. Do not paste secrets
+into terminals, commits, issue comments, prompts, or screenshots.
+
+## AskBuddy Public Route Failing
+
+Symptoms:
+
+- `/ask-buddy/` loads but answers return "buddy is offline" or
+  `buddy_not_configured`.
+- `/api/askbuddy` returns `forbidden_origin`, `rate_limited`,
+  `traffic_surge`, `corpus_write_failed`, or backend missing.
+
+Likely causes:
+
+- Missing `BUDDY_BACKEND_URL`, `BUDDY_CF_ACCESS_CLIENT_ID`, or
+  `BUDDY_CF_ACCESS_CLIENT_SECRET`.
+- Buddy backend is down or unreachable through Cloudflare Access.
+- Backend responded without `corpus_written:true`.
+- `ASKBUDDY_USAGE`/`JOKE_KV` throttling is blocking traffic.
+- Origin/referrer mismatch from a preview or native wrapper.
+
+Checks:
+
+```bash
+npm run build
+curl -I https://aiit-threshold.com/ask-buddy/
+curl -s https://aiit-threshold.com/api/auth/me
+```
+
+Also check Cloudflare Pages Function logs for the deployment and confirm the
+Buddy backend health from the backend host, not from this repo.
+
+Rollback/safe action:
+
+- If source changed, roll back the last Cloudflare Pages deployment or revert
+  the bad commit.
+- If dashboard config changed, restore the last known-good Cloudflare env vars
+  and KV bindings.
+- If Buddy backend is unhealthy, show the honest offline path and fix backend
+  health separately.
+
+What not to do:
+
+- Do not add a direct Anthropic/model fallback for Buddy.
+- Do not bypass the ingestion gate.
+- Do not disable corpus write confirmation to make the UI look healthy.
+
+## Buddy Backend Reachable But Not Generating
+
+Symptoms:
+
+- Cloudflare Function reaches the backend but returns empty answer,
+  `corpus_write_failed`, `buddy_bad_response`, or queue states never resolve.
+
+Likely causes:
+
+- Backend queue pressure.
+- Backend auth token mismatch.
+- Backend route contract changed.
+- Buddy generated but did not confirm corpus ingestion.
+
+Checks:
+
+- Confirm Cloudflare Access service token values are current in dashboard.
+- Confirm optional `BUDDY_BACKEND_TOKEN` matches backend policy if required.
+- Inspect backend logs for the request id returned by `/api/askbuddy`.
+- Verify backend `/ask` and `/ask_poll` response shape includes
+  `corpus_written:true` for completed answers.
+
+Rollback/safe action:
+
+- Roll back backend changes if the route contract changed.
+- Keep public route fail-closed until corpus write confirmation is restored.
+
+What not to do:
+
+- Do not treat a response as successful without `corpus_written:true`.
+- Do not start or restart Buddy from this site repo.
+
+## Cloudflare Pages Deploy Failed
+
+Symptoms:
+
+- Cloudflare Pages build fails.
+- Production stays on an older deployment.
+- Preview deploy never appears or shows a build error.
+
+Likely causes:
+
+- `npm ci` failure.
+- `npm run build` failure.
+- Build output directory mismatch.
+- Cloudflare project build command drifted from repo docs.
+
+Checks:
+
+```bash
+git status -sb
+npm ci
+npm run build
+git diff --check
+```
+
+Confirm Cloudflare Pages settings:
+
+- build command: `npm run build`
+- output directory: `dist`
+- production branch: `master`
+
+Rollback/safe action:
+
+- Leave the last successful Cloudflare deployment active.
+- Revert the bad commit or push a fix.
+- If the Cloudflare dashboard command drifted, restore it to this runbook.
+
+What not to do:
+
+- Do not commit `dist/`, `node_modules/`, local logs, `.env`, or screenshots.
+- Do not edit unrelated dirty files to force a deploy.
+
+## GitHub OAuth Login Broken
+
+Symptoms:
+
+- Login redirects fail.
+- Callback returns missing code/state, token exchange failed, or loops back to
+  login.
+- `/api/auth/me` always returns `{"user":null}` after login.
+
+Likely causes:
+
+- Missing `GITHUB_CLIENT_ID` or `GITHUB_CLIENT_SECRET`.
+- Missing `AUTH_KV`.
+- GitHub OAuth callback URL mismatch.
+- Preview and production OAuth apps are mixed.
+
+Checks:
+
+```bash
+curl -s https://aiit-threshold.com/api/auth/me
+```
+
+Verify dashboard settings and GitHub OAuth callback:
+
+- Production: `https://aiit-threshold.com/api/auth/github/callback`
+- Preview: see `docs/PREVIEW_AUTH_SETUP.md`
+
+Rollback/safe action:
+
+- Restore the previous OAuth app settings or Cloudflare env values.
+- Roll back only if source redirect normalization changed.
+
+What not to do:
+
+- Do not commit OAuth client secrets.
+- Do not loosen redirect target validation.
+
+## AUTH_KV Missing
+
+Symptoms:
+
+- Login sessions do not persist.
+- Paper Game collection returns `auth_kv_missing` or cannot sync.
+- Buddy thread export/report fails.
+- Pro tier lookup fails.
+
+Likely causes:
+
+- `AUTH_KV` binding absent in production or preview.
+- Binding points to the wrong namespace.
+- Preview environment lacks bindings that production has.
+
+Checks:
+
+- Inspect Cloudflare Pages project `buddy-bb4` Functions bindings.
+- Confirm `AUTH_KV` exists separately for production and preview.
+- Use `/api/auth/me` while logged out and logged in.
+
+Rollback/safe action:
+
+- Re-bind `AUTH_KV` to the last known-good namespace.
+- If a namespace was deleted, restore from Cloudflare/account backup if
+  available and treat session loss as an account incident.
+
+What not to do:
+
+- Do not create a new empty namespace and call the incident fixed without
+  accepting session/data loss.
+- Do not store session data in source files.
+
+## Paper Game Sync Broken
+
+Symptoms:
+
+- Collection does not save.
+- User sees login required or `auth_kv_missing`.
+- Collected slugs vanish between sessions.
+
+Likely causes:
+
+- User is not logged in.
+- `AUTH_KV` missing or wrong namespace.
+- Browser is blocking cookies.
+- Preview OAuth not configured.
+
+Checks:
+
+```bash
+curl -I https://aiit-threshold.com/paper-game/
+curl -s https://aiit-threshold.com/api/auth/me
+```
+
+In browser, confirm login state and watch network calls to
+`/api/paper-game/collection`.
+
+Rollback/safe action:
+
+- Restore `AUTH_KV` binding or OAuth settings.
+- Roll back only if the paper-game page or collection endpoint changed.
+
+What not to do:
+
+- Do not write collection state to localStorage as the only source of truth for
+  logged-in users.
+- Do not merge a fix that bypasses auth.
+
+## Stripe Webhook Failed
+
+Symptoms:
+
+- Stripe dashboard shows webhook failures.
+- Pro tier is not activated.
+- Paid download verification fails.
+- Webhook returns invalid signature or secret not configured.
+
+Likely causes:
+
+- Missing `STRIPE_WEBHOOK_SECRET`.
+- Wrong webhook secret for production versus preview/test.
+- Missing `AUTH_KV`.
+- Stripe secret key mismatch for paid download verification.
+
+Checks:
+
+- Inspect Stripe webhook event delivery status.
+- Confirm Cloudflare Function logs for `/api/stripe/webhook`.
+- Confirm `STRIPE_WEBHOOK_SECRET`, `STRIPE_SECRET_KEY`, and `AUTH_KV` in
+  Cloudflare dashboard.
+
+Rollback/safe action:
+
+- Restore previous Stripe webhook secret or endpoint config.
+- Replay failed Stripe events after fixing the root cause.
+- If source changed, roll back the deployment before replaying.
+
+What not to do:
+
+- Do not disable signature verification.
+- Do not paste Stripe secrets into logs or prompts.
+
+## Text/SMS Alert Lane Failed
+
+Symptoms:
+
+- Expected sale/report/incident text alerts do not arrive.
+- Email notifications work but SMS gateway delivery does not.
+
+Likely causes:
+
+- Alert lane is outside this repo and not documented.
+- MailChannels/Cloudflare Email sending is unavailable.
+- Carrier gateway addresses or sender policy changed.
+
+Checks:
+
+- Confirm whether alert-lane secrets are configured in Cloudflare or another
+  automation host.
+- Check Cloudflare Function logs for report/payment notification errors.
+- Verify email delivery provider status.
+
+Rollback/safe action:
+
+- Restore previous notification env values in the owning service.
+- Keep payment/report storage active even if notification delivery is degraded.
+
+What not to do:
+
+- Do not hard-code private phone numbers, tokens, or alert credentials into new
+  source files.
+- Do not block checkout/report success solely because alert delivery failed.
+
+## Emergency Rollback
+
+Use this when production is user-visible broken and a source change is the
+likely cause.
+
+Steps:
+
+1. Open Cloudflare Pages project `buddy-bb4`.
+2. Go to Deployments.
+3. Promote the last known-good production deployment.
+4. Run smoke checks from `docs/DEPLOYMENT.md`.
+5. Create a git revert PR for the bad commit.
+
+Safe command path:
+
+```bash
+git status -sb
+git revert <bad-commit-sha>
+npm run build
+git diff --check
+git push origin <rollback-branch>
+```
+
+What not to do:
+
+- Do not use `git reset --hard` in a dirty working tree.
+- Do not delete KV namespaces.
+- Do not rotate secrets unless compromise is suspected.
+- Do not modify Buddy runtime/tunnel wiring from this site repo.


### PR DESCRIPTION
## Summary
- Add deployment, environment, incident, and API surface documentation for the Cloudflare Pages site.
- Add a minimal GitHub Actions build check: npm ci + npm run build.
- Add README.md with local setup, deployment doc pointers, and dashboard binding warnings.

## Validation
- npm ci
- npm run build
- git diff --check
- ASCII/secrets hygiene checks over new docs/workflow

## Still Not Codified In Repo
- Cloudflare Pages dashboard project settings and production/preview env values.
- Cloudflare KV namespace creation/binding IDs.
- GitHub OAuth app settings and callback ownership.
- Stripe webhook endpoint/secret configuration.
- Buddy backend health, Cloudflare Access policy, and tunnel/runtime wiring.
- Any external TextNow/alert lane automation, if it exists outside this repo.

No runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs covering project overview, API surfaces and behaviors, deployment procedures, environment bindings/requirements, and an incident response runbook with troubleshooting and rollback guidance.

* **Chores**
  * Added an automated build workflow to run on pull requests and on pushes to the master branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIIT-GLITCH/buddy/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->